### PR TITLE
Replace `rand` with `ark_std::rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,14 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features
 
 bench-utils = { git = "https://github.com/arkworks-rs/utils", default-features = false }
 
-blake2 = { version = "0.8", default-features = false }
-digest = "0.8"
+blake2 = { version = "0.9", default-features = false }
+digest = "0.9"
 
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", optional = true, default-features = false }
 ark-snark = { git = "https://github.com/arkworks-rs/snark", default-features = false }
 
 ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative.git", optional = true, default-features = false }
 
-rand = { version = "0.7", default-features = false }
 rayon = { version = "1.0", optional = true }
 derivative = { version = "2.0", features = ["use_core"] }
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
@@ -47,5 +46,3 @@ ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves", default-f
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "curve", "r1cs" ] }
 ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "curve", "r1cs" ] }
 ark-mnt6-298 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "r1cs" ] }
-
-rand_xorshift = { version = "0.2" }

--- a/cp-benches/Cargo.toml
+++ b/cp-benches/Cargo.toml
@@ -14,11 +14,9 @@ edition = "2018"
 
 [dev-dependencies]
 ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves/", default-features = false }
-blake2 = { version = "0.8", default-features = false }
+blake2 = { version = "0.9", default-features = false }
 criterion = "0.3.1"
 crypto-primitives = { path = "../crypto-primitives" }
-rand = { version = "0.7" }
-rand_xorshift = { version = "0.2" }
 
 ################################# Benchmarks ##################################
 

--- a/cp-benches/benches/crypto_primitives/comm.rs
+++ b/cp-benches/benches/crypto_primitives/comm.rs
@@ -1,5 +1,3 @@
-use rand;
-
 #[macro_use]
 extern crate criterion;
 
@@ -18,14 +16,14 @@ impl Window for CommWindow {
 fn pedersen_comm_setup(c: &mut Criterion) {
     c.bench_function("Pedersen Commitment Setup", move |b| {
         b.iter(|| {
-            let mut rng = &mut rand::thread_rng();
+            let mut rng = &mut ark_std::test_rng();
             Commitment::<Edwards, CommWindow>::setup(&mut rng).unwrap()
         })
     });
 }
 
 fn pedersen_comm_eval(c: &mut Criterion) {
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let parameters = Commitment::<Edwards, CommWindow>::setup(&mut rng).unwrap();
     let input = vec![5u8; 128];
     c.bench_function("Pedersen Commitment Eval", move |b| {

--- a/cp-benches/benches/crypto_primitives/crh.rs
+++ b/cp-benches/benches/crypto_primitives/crh.rs
@@ -1,5 +1,3 @@
-use rand;
-
 #[macro_use]
 extern crate criterion;
 
@@ -18,14 +16,14 @@ impl Window for HashWindow {
 fn pedersen_crh_setup(c: &mut Criterion) {
     c.bench_function("Pedersen CRH Setup", move |b| {
         b.iter(|| {
-            let mut rng = &mut rand::thread_rng();
+            let mut rng = &mut ark_std::test_rng();
             CRH::<Edwards, HashWindow>::setup(&mut rng).unwrap()
         })
     });
 }
 
 fn pedersen_crh_eval(c: &mut Criterion) {
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let parameters = CRH::<Edwards, HashWindow>::setup(&mut rng).unwrap();
     let input = vec![5u8; 128];
     c.bench_function("Pedersen CRH Eval", move |b| {

--- a/cp-benches/benches/crypto_primitives/prf.rs
+++ b/cp-benches/benches/crypto_primitives/prf.rs
@@ -5,10 +5,10 @@ extern crate criterion;
 
 use criterion::Criterion;
 use crypto_primitives::prf::*;
-use rand::Rng;
+use ark_std::rand::Rng;
 
 fn blake2s_prf_eval(c: &mut Criterion) {
-    let rng = &mut rand::thread_rng();
+    let rng = &mut ark_std::test_rng();
     let input: [u8; 32] = rng.gen();
     let seed: [u8; 32] = rng.gen();
     c.bench_function("Blake2s PRF Eval", move |b| {

--- a/cp-benches/benches/crypto_primitives/signature.rs
+++ b/cp-benches/benches/crypto_primitives/signature.rs
@@ -5,7 +5,7 @@ use algebra::ed_on_bls12_377::EdwardsProjective as Edwards;
 use blake2::Blake2s;
 use criterion::Criterion;
 use crypto_primitives::signature::{schnorr::*, SignatureScheme};
-use rand::{self, Rng};
+use ark_std::rand::Rng;
 
 type SchnorrEdwards = Schnorr<Edwards, Blake2s>;
 fn schnorr_signature_setup(c: &mut Criterion) {
@@ -18,7 +18,7 @@ fn schnorr_signature_setup(c: &mut Criterion) {
 }
 
 fn schnorr_signature_keygen(c: &mut Criterion) {
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let parameters = SchnorrEdwards::setup(&mut rng).unwrap();
 
     c.bench_function("SchnorrEdwards: KeyGen", move |b| {
@@ -30,7 +30,7 @@ fn schnorr_signature_keygen(c: &mut Criterion) {
 }
 
 fn schnorr_signature_sign(c: &mut Criterion) {
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let parameters = SchnorrEdwards::setup(&mut rng).unwrap();
     let (_, sk) = SchnorrEdwards::keygen(&parameters, &mut rng).unwrap();
     let message = [100u8; 128];
@@ -44,7 +44,7 @@ fn schnorr_signature_sign(c: &mut Criterion) {
 }
 
 fn schnorr_signature_verify(c: &mut Criterion) {
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let parameters = SchnorrEdwards::setup(&mut rng).unwrap();
     let (pk, sk) = SchnorrEdwards::keygen(&parameters, &mut rng).unwrap();
     let message = [100u8; 128];
@@ -56,7 +56,7 @@ fn schnorr_signature_verify(c: &mut Criterion) {
 }
 
 fn schnorr_signature_randomize_pk(c: &mut Criterion) {
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let parameters = SchnorrEdwards::setup(&mut rng).unwrap();
     let (pk, _) = SchnorrEdwards::keygen(&parameters, &mut rng).unwrap();
     let randomness: [u8; 32] = rng.gen();
@@ -67,7 +67,7 @@ fn schnorr_signature_randomize_pk(c: &mut Criterion) {
 }
 
 fn schnorr_signature_randomize_signature(c: &mut Criterion) {
-    let mut rng = &mut rand::thread_rng();
+    let mut rng = &mut ark_std::test_rng();
     let parameters = SchnorrEdwards::setup(&mut rng).unwrap();
     let (_, sk) = SchnorrEdwards::keygen(&parameters, &mut rng).unwrap();
     let randomness: [u8; 32] = rng.gen();

--- a/src/commitment/blake2s/constraints.rs
+++ b/src/commitment/blake2s/constraints.rs
@@ -82,7 +82,6 @@ mod test {
     use ark_r1cs_std::prelude::*;
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::rand::Rng;
-    use ark_std::test_rng;
 
     #[test]
     fn commitment_gadget_test() {

--- a/src/commitment/blake2s/constraints.rs
+++ b/src/commitment/blake2s/constraints.rs
@@ -81,8 +81,8 @@ mod test {
     use ark_ed_on_bls12_381::Fq as Fr;
     use ark_r1cs_std::prelude::*;
     use ark_relations::r1cs::ConstraintSystem;
+    use ark_std::rand::Rng;
     use ark_std::test_rng;
-    use rand::Rng;
 
     #[test]
     fn commitment_gadget_test() {
@@ -90,7 +90,7 @@ mod test {
 
         let input = [1u8; 32];
 
-        let rng = &mut test_rng();
+        let rng = &mut ark_std::test_rng();
 
         type TestCOMM = Commitment;
         type TestCOMMGadget = CommGadget;

--- a/src/commitment/blake2s/mod.rs
+++ b/src/commitment/blake2s/mod.rs
@@ -1,8 +1,8 @@
 use super::CommitmentScheme;
 use crate::Error;
+use ark_std::rand::Rng;
 use blake2::Blake2s as b2s;
 use digest::Digest;
-use rand::Rng;
 
 pub struct Commitment;
 
@@ -24,10 +24,10 @@ impl CommitmentScheme for Commitment {
         r: &Self::Randomness,
     ) -> Result<Self::Output, Error> {
         let mut h = b2s::new();
-        h.input(input);
-        h.input(r.as_ref());
+        h.update(input);
+        h.update(r.as_ref());
         let mut result = [0u8; 32];
-        result.copy_from_slice(&h.result());
+        result.copy_from_slice(&h.finalize());
         Ok(result)
     }
 }

--- a/src/commitment/injective_map/constraints.rs
+++ b/src/commitment/injective_map/constraints.rs
@@ -15,7 +15,7 @@ use ark_r1cs_std::{
 };
 use ark_relations::r1cs::SynthesisError;
 
-use core::marker::PhantomData;
+use ark_std::marker::PhantomData;
 
 type ConstraintF<C> = <<C as ProjectiveCurve>::BaseField as Field>::BasePrimeField;
 

--- a/src/commitment/injective_map/mod.rs
+++ b/src/commitment/injective_map/mod.rs
@@ -1,10 +1,10 @@
 use crate::Error;
-use core::marker::PhantomData;
-use rand::Rng;
+use ark_std::marker::PhantomData;
 
 use super::{pedersen, CommitmentScheme};
 pub use crate::crh::injective_map::InjectiveMap;
 use ark_ec::ProjectiveCurve;
+use ark_std::rand::Rng;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/src/commitment/mod.rs
+++ b/src/commitment/mod.rs
@@ -1,6 +1,6 @@
 use ark_ff::UniformRand;
-use core::{fmt::Debug, hash::Hash};
-use rand::Rng;
+use ark_std::rand::Rng;
+use ark_std::{fmt::Debug, hash::Hash};
 
 use ark_ff::bytes::ToBytes;
 

--- a/src/commitment/pedersen/mod.rs
+++ b/src/commitment/pedersen/mod.rs
@@ -1,12 +1,10 @@
 use crate::{Error, Vec};
 use ark_ec::ProjectiveCurve;
-use ark_ff::{
-    bytes::ToBytes, BitIteratorLE, Field, FpParameters, PrimeField, ToConstraintField, UniformRand,
-};
+use ark_ff::{bytes::ToBytes, BitIteratorLE, Field, FpParameters, PrimeField, ToConstraintField};
 use ark_std::io::{Result as IoResult, Write};
-
-use core::marker::PhantomData;
-use rand::Rng;
+use ark_std::marker::PhantomData;
+use ark_std::rand::Rng;
+use ark_std::UniformRand;
 
 use super::CommitmentScheme;
 

--- a/src/crh/bowe_hopwood/constraints.rs
+++ b/src/crh/bowe_hopwood/constraints.rs
@@ -106,7 +106,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use rand::Rng;
+    use ark_std::rand::Rng;
 
     use crate::crh::{
         bowe_hopwood::{constraints::CRHGadget, CRH},

--- a/src/crh/bowe_hopwood/mod.rs
+++ b/src/crh/bowe_hopwood/mod.rs
@@ -1,9 +1,9 @@
 use crate::{Error, Vec};
-use core::{
+use ark_std::rand::Rng;
+use ark_std::{
     fmt::{Debug, Formatter, Result as FmtResult},
     marker::PhantomData,
 };
-use rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -12,8 +12,9 @@ use crate::crh::FixedLengthCRH;
 use ark_ec::{
     twisted_edwards_extended::GroupProjective as TEProjective, ProjectiveCurve, TEModelParameters,
 };
-use ark_ff::{biginteger::BigInteger, fields::PrimeField, UniformRand};
+use ark_ff::{biginteger::BigInteger, fields::PrimeField};
 use ark_std::cfg_chunks;
+use ark_std::UniformRand;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/src/crh/injective_map/mod.rs
+++ b/src/crh/injective_map/mod.rs
@@ -1,7 +1,7 @@
 use crate::{CryptoError, Error};
 use ark_ff::bytes::ToBytes;
-use core::{fmt::Debug, hash::Hash, marker::PhantomData};
-use rand::Rng;
+use ark_std::rand::Rng;
+use ark_std::{fmt::Debug, hash::Hash, marker::PhantomData};
 
 use super::{pedersen, FixedLengthCRH};
 use ark_ec::{

--- a/src/crh/mod.rs
+++ b/src/crh/mod.rs
@@ -1,6 +1,6 @@
 use ark_ff::bytes::ToBytes;
-use core::hash::Hash;
-use rand::Rng;
+use ark_std::hash::Hash;
+use ark_std::rand::Rng;
 
 pub mod bowe_hopwood;
 pub mod injective_map;

--- a/src/crh/pedersen/constraints.rs
+++ b/src/crh/pedersen/constraints.rs
@@ -99,8 +99,8 @@ mod test {
     use crate::crh::{pedersen, pedersen::constraints::*, FixedLengthCRH, FixedLengthCRHGadget};
     use ark_ed_on_bls12_381::{constraints::EdwardsVar, EdwardsProjective as JubJub, Fq as Fr};
     use ark_relations::r1cs::{ConstraintSystem, ConstraintSystemRef};
+    use ark_std::rand::Rng;
     use ark_std::test_rng;
-    use rand::Rng;
 
     type TestCRH = pedersen::CRH<JubJub, Window>;
     type TestCRHGadget = CRHGadget<JubJub, EdwardsVar, Window>;

--- a/src/crh/pedersen/mod.rs
+++ b/src/crh/pedersen/mod.rs
@@ -1,9 +1,9 @@
 use crate::{Error, Vec};
-use core::{
+use ark_std::rand::Rng;
+use ark_std::{
     fmt::{Debug, Formatter, Result as FmtResult},
     marker::PhantomData,
 };
-use rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/src/merkle_tree/constraints.rs
+++ b/src/merkle_tree/constraints.rs
@@ -131,8 +131,6 @@ mod test {
     };
     use ark_ed_on_bls12_381::{constraints::EdwardsVar, EdwardsProjective as JubJub, Fq};
     use ark_relations::r1cs::ConstraintSystem;
-    use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
 
     use super::*;
 
@@ -156,7 +154,7 @@ mod test {
     type JubJubMerkleTree = MerkleTree<JubJubMerkleTreeParams>;
 
     fn generate_merkle_tree(leaves: &[[u8; 30]], use_bad_root: bool) -> () {
-        let mut rng = XorShiftRng::seed_from_u64(9174123u64);
+        let mut rng = ark_std::test_rng();
 
         let crh_parameters = H::setup(&mut rng).unwrap();
         let tree = JubJubMerkleTree::new(crh_parameters.clone(), leaves).unwrap();

--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -1,6 +1,6 @@
 use crate::{crh::FixedLengthCRH, Vec};
 use ark_ff::bytes::ToBytes;
-use core::fmt;
+use ark_std::fmt;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;
@@ -352,8 +352,6 @@ mod test {
     };
     use ark_ed_on_bls12_381::EdwardsProjective as JubJub;
     use ark_ff::Zero;
-    use rand::SeedableRng;
-    use rand_xorshift::XorShiftRng;
 
     #[derive(Clone)]
     pub(super) struct Window4x256;
@@ -373,7 +371,7 @@ mod test {
     type JubJubMerkleTree = MerkleTree<JubJubMerkleTreeParams>;
 
     fn generate_merkle_tree<L: ToBytes + Clone + Eq>(leaves: &[L]) -> () {
-        let mut rng = XorShiftRng::seed_from_u64(9174123u64);
+        let mut rng = ark_std::test_rng();
 
         let crh_parameters = H::setup(&mut rng).unwrap();
         let tree = JubJubMerkleTree::new(crh_parameters.clone(), &leaves).unwrap();
@@ -413,7 +411,7 @@ mod test {
     }
 
     fn bad_merkle_tree_verify<L: ToBytes + Clone + Eq>(leaves: &[L]) -> () {
-        let mut rng = XorShiftRng::seed_from_u64(13423423u64);
+        let mut rng = ark_std::test_rng();
 
         let crh_parameters = H::setup(&mut rng).unwrap();
         let tree = JubJubMerkleTree::new(crh_parameters.clone(), &leaves).unwrap();

--- a/src/prf/blake2s/mod.rs
+++ b/src/prf/blake2s/mod.rs
@@ -20,10 +20,10 @@ impl PRF for Blake2s {
     fn evaluate(seed: &Self::Seed, input: &Self::Input) -> Result<Self::Output, CryptoError> {
         let eval_time = start_timer!(|| "Blake2s::Eval");
         let mut h = B2s::new();
-        h.input(seed.as_ref());
-        h.input(input.as_ref());
+        h.update(seed.as_ref());
+        h.update(input.as_ref());
         let mut result = [0u8; 32];
-        result.copy_from_slice(&h.result());
+        result.copy_from_slice(&h.finalize());
         end_timer!(eval_time);
         Ok(result)
     }
@@ -79,10 +79,10 @@ impl Blake2sWithParameterBlock {
         use digest::*;
         let eval_time = start_timer!(|| "Blake2sWithParameterBlock::Eval");
         let mut h = VarBlake2s::with_parameter_block(&self.parameters());
-        h.input(input.as_ref());
+        h.update(input.as_ref());
         end_timer!(eval_time);
-        let mut buf = Vec::with_capacity(h.output_size());
-        h.variable_result(|res| buf.extend_from_slice(res));
+        let mut buf = Vec::with_capacity(digest::VariableOutput::output_size(&h));
+        h.finalize_variable(|res| buf.extend_from_slice(res));
         buf
     }
 }

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -1,7 +1,7 @@
 use crate::Error;
 use ark_ff::bytes::ToBytes;
-use core::hash::Hash;
-use rand::Rng;
+use ark_std::hash::Hash;
+use ark_std::rand::Rng;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/src/signature/schnorr/mod.rs
+++ b/src/signature/schnorr/mod.rs
@@ -6,9 +6,9 @@ use ark_ff::{
     to_bytes, One, ToConstraintField, UniformRand, Zero,
 };
 use ark_std::io::{Result as IoResult, Write};
-use core::{hash::Hash, marker::PhantomData};
+use ark_std::rand::Rng;
+use ark_std::{hash::Hash, marker::PhantomData};
 use digest::Digest;
-use rand::Rng;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;


### PR DESCRIPTION
This PR makes a number of changes:

1. bump up the versions of Blake2s and Digest.
2. replace `rand` with `ark_std::rand`.
3. remove `rand_xorshift` from the tests.