### PR TITLE
Synchronize with the change in nonnative

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ digest = "0.9"
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", optional = true, default-features = false }
 ark-snark = { git = "https://github.com/arkworks-rs/snark", default-features = false }
 
-ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative.git", optional = true, default-features = false }
+ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative", optional = true, default-features = false }
 
 rayon = { version = "1.0", optional = true }
 derivative = { version = "2.0", features = ["use_core"] }

--- a/src/snark/constraints.rs
+++ b/src/snark/constraints.rs
@@ -7,6 +7,7 @@ use ark_r1cs_std::{
     fields::fp::{AllocatedFp, FpVar},
     R1CSVar,
 };
+use ark_relations::r1cs::OptimizationGoal;
 use ark_relations::{
     lc, ns,
     r1cs::{
@@ -20,7 +21,6 @@ use ark_std::{
     marker::PhantomData,
     vec::{IntoIter, Vec},
 };
-use ark_relations::r1cs::OptimizationGoal;
 
 /// This implements constraints for SNARK verifiers.
 pub trait SNARKGadget<F: PrimeField, ConstraintF: PrimeField, S: SNARK<F>> {
@@ -465,7 +465,7 @@ where
         let optimization_type = match cs.optimization_goal() {
             OptimizationGoal::None => OptimizationType::Constraints,
             OptimizationGoal::Constraints => OptimizationType::Constraints,
-            OptimizationGoal::Weight => OptimizationType::Weight
+            OptimizationGoal::Weight => OptimizationType::Weight,
         };
 
         let params = get_params(F::size_in_bits(), CF::size_in_bits(), optimization_type);
@@ -578,7 +578,7 @@ where
             let optimization_type = match cs.optimization_goal() {
                 OptimizationGoal::None => OptimizationType::Constraints,
                 OptimizationGoal::Constraints => OptimizationType::Constraints,
-                OptimizationGoal::Weight => OptimizationType::Weight
+                OptimizationGoal::Weight => OptimizationType::Weight,
             };
 
             let params = get_params(F::size_in_bits(), CF::size_in_bits(), optimization_type);

--- a/src/snark/constraints.rs
+++ b/src/snark/constraints.rs
@@ -1,5 +1,5 @@
 use ark_ff::{BigInteger, FpParameters, PrimeField};
-use ark_nonnative_field::params::get_params;
+use ark_nonnative_field::params::{get_params, OptimizationType};
 use ark_nonnative_field::{AllocatedNonNativeFieldVar, NonNativeFieldVar};
 use ark_r1cs_std::prelude::*;
 use ark_r1cs_std::{
@@ -20,6 +20,7 @@ use ark_std::{
     marker::PhantomData,
     vec::{IntoIter, Vec},
 };
+use ark_relations::r1cs::OptimizationGoal;
 
 /// This implements constraints for SNARK verifiers.
 pub trait SNARKGadget<F: PrimeField, ConstraintF: PrimeField, S: SNARK<F>> {
@@ -461,7 +462,13 @@ where
         let ns = cs.into();
         let cs = ns.cs();
 
-        let params = get_params(F::size_in_bits(), CF::size_in_bits());
+        let optimization_type = match cs.optimization_goal() {
+            OptimizationGoal::None => OptimizationType::Constraints,
+            OptimizationGoal::Constraints => OptimizationType::Constraints,
+            OptimizationGoal::Weight => OptimizationType::Weight
+        };
+
+        let params = get_params(F::size_in_bits(), CF::size_in_bits(), optimization_type);
 
         let obj = f()?;
 
@@ -568,7 +575,13 @@ where
                 val: field_allocation,
             })
         } else {
-            let params = get_params(F::size_in_bits(), CF::size_in_bits());
+            let optimization_type = match cs.optimization_goal() {
+                OptimizationGoal::None => OptimizationType::Constraints,
+                OptimizationGoal::Constraints => OptimizationType::Constraints,
+                OptimizationGoal::Weight => OptimizationType::Weight
+            };
+
+            let params = get_params(F::size_in_bits(), CF::size_in_bits(), optimization_type);
 
             // Step 1: use BooleanInputVar to convert them into booleans
             let boolean_allocation = BooleanInputVar::<F, CF>::from_field_elements(src)?;


### PR DESCRIPTION
Nonnative now no longer uses the density-optimized feature and requires this information to be passed directly. 

As a result, if a library uses the `get_params` function directly, it will now need to research the optimization goal (by looking at the ConstraintSystem's optimization goal).

This closes #25 