### PR TITLE
Update `NonNativeFieldInputVar` to match the upstream update

### DIFF
--- a/src/snark/constraints.rs
+++ b/src/snark/constraints.rs
@@ -632,6 +632,7 @@ where
 
                 field_allocation.push(NonNativeFieldVar::<F, CF>::Var(
                     AllocatedNonNativeFieldVar::<F, CF> {
+                        cs: cs.clone(),
                         limbs,
                         num_of_additions_over_normal_form: CF::zero(),
                         is_in_the_normal_form: true,


### PR DESCRIPTION
cc @Will-Lin4 as this might require you to do a `cargo update`.

The nonnative adds a field `cs` to enable tracking the optimization type for constant, allocated variables. This PR reconciles with that change.