### PR TITLE
Fix no_std issue for merkle tree constraints

### DIFF
--- a/src/merkle_tree/constraints.rs
+++ b/src/merkle_tree/constraints.rs
@@ -10,7 +10,7 @@ use ark_r1cs_std::prelude::*;
 use ark_r1cs_std::ToBytesGadget;
 use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_std::borrow::Borrow;
-
+use ark_std::vec::Vec;
 /// Represents a merkle tree path gadget.
 pub struct PathVar<P, LeafH, TwoToOneH, ConstraintF>
 where


### PR DESCRIPTION
I forgot to include `ark_std::vec::Vec` in merkle-tree/constraints. Sorry

This PR will fix that issue

Closes: #39 