### PR TITLE
Fix `no_std` when the R1CS feature is on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,5 +117,5 @@ jobs:
 
       - name: crypto-primitives
         run: |
-          cargo build --no-default-features --target aarch64-unknown-none
-          cargo check --examples --no-default-features --target aarch64-unknown-none
+          cargo build --no-default-features --features=r1cs --target aarch64-unknown-none
+          cargo check --examples --no-default-features --features=r1cs --target aarch64-unknown-none

--- a/src/encryption/elgamal/constraints.rs
+++ b/src/encryption/elgamal/constraints.rs
@@ -10,7 +10,7 @@ use ark_ff::{
     fields::{Field, PrimeField},
     to_bytes, Zero,
 };
-use core::{borrow::Borrow, marker::PhantomData};
+use ark_std::{borrow::Borrow, marker::PhantomData, vec::Vec};
 
 pub type ConstraintF<C> = <<C as ProjectiveCurve>::BaseField as Field>::BasePrimeField;
 


### PR DESCRIPTION
Our existing CI tests for `no_std` always run on `--no-default-features` and therefore it does not capture the case of R1CS. 

This PR fixes the `no_std` issue and also lets the no_std test covers the case with the R1CS feature. Our other repos likely need a similar treatment. 

This closes #51 