### PR TITLE
Made Bowe-Hopwood Usable as a Merkle Tree Hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Pending
 
-Implemented TwoToOneCRH for Bowe-Hopwood CRH
-
 ### Breaking changes
 
 - [\#56](https://github.com/arkworks-rs/crypto-primitives/pull/56) Compress the output of the Bowe-Hopwood-Pedersen CRH to a single field element, in line with the Zcash specification.
 
 ### Features
+
+- [\#59](https://github.com/arkworks-rs/crypto-primitives/pull/59) Implemented `TwoToOneCRH` for Bowe-Hopwood CRH.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+Implemented TwoToOneCRH for Bowe-Hopwood CRH
+
 ### Breaking changes
 
 - [\#56](https://github.com/arkworks-rs/crypto-primitives/pull/56) Compress the output of the Bowe-Hopwood-Pedersen CRH to a single field element, in line with the Zcash specification.

--- a/src/crh/bowe_hopwood/constraints.rs
+++ b/src/crh/bowe_hopwood/constraints.rs
@@ -1,14 +1,16 @@
-use core::{borrow::Borrow, marker::PhantomData};
+use core::{borrow::Borrow, iter, marker::PhantomData};
 
 use crate::{
     crh::{
         bowe_hopwood::{Parameters, CHUNK_SIZE, CRH},
-        pedersen::Window,
-        CRHGadget as CRGGadgetTrait,
+        pedersen::{self, Window},
+        CRHGadget as CRHGadgetTrait, TwoToOneCRHGadget, CRH as CRHTrait,
     },
     Vec,
 };
-use ark_ec::{ModelParameters, TEModelParameters};
+use ark_ec::{
+    twisted_edwards_extended::GroupProjective as TEProjective, ModelParameters, TEModelParameters,
+};
 use ark_ff::Field;
 use ark_r1cs_std::{
     alloc::AllocVar, groups::curves::twisted_edwards::AffineVar, prelude::*, uint8::UInt8,
@@ -37,7 +39,7 @@ where
     _base_field: PhantomData<F>,
 }
 
-impl<P, F, W> CRGGadgetTrait<CRH<P, W>, ConstraintF<P>> for CRHGadget<P, F>
+impl<P, F, W> CRHGadgetTrait<CRH<P, W>, ConstraintF<P>> for CRHGadget<P, F>
 where
     for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
     F: FieldVar<P::BaseField, ConstraintF<P>>,
@@ -85,6 +87,42 @@ where
     }
 }
 
+impl<P, F, W> TwoToOneCRHGadget<CRH<P, W>, ConstraintF<P>> for CRHGadget<P, F>
+where
+    for<'a> &'a F: FieldOpsBounds<'a, P::BaseField, F>,
+    F: FieldVar<P::BaseField, ConstraintF<P>>,
+    F: TwoBitLookupGadget<ConstraintF<P>, TableConstant = P::BaseField>
+        + ThreeBitCondNegLookupGadget<ConstraintF<P>, TableConstant = P::BaseField>,
+    P: TEModelParameters,
+    W: Window,
+{
+    type OutputVar = F;
+    type ParametersVar = ParametersVar<P, W>;
+
+    #[tracing::instrument(target = "r1cs", skip(parameters))]
+    fn evaluate(
+        parameters: &Self::ParametersVar,
+        left_input: &[UInt8<ConstraintF<P>>],
+        right_input: &[UInt8<ConstraintF<P>>],
+    ) -> Result<Self::OutputVar, SynthesisError> {
+        let input_size_bytes = pedersen::CRH::<TEProjective<P>, W>::INPUT_SIZE_BITS / 8;
+
+        // assume equality of left and right length
+        assert_eq!(left_input.len(), right_input.len());
+        // assume sum of left and right length is at most the CRH length limit
+        assert!(left_input.len() + right_input.len() <= input_size_bytes);
+
+        let num_trailing_zeros = input_size_bytes - (left_input.len() + right_input.len());
+        let chained_input: Vec<_> = left_input
+            .to_vec()
+            .into_iter()
+            .chain(right_input.to_vec().into_iter())
+            .chain(iter::repeat(UInt8::constant(0u8)).take(num_trailing_zeros))
+            .collect();
+        <Self as CRHGadgetTrait<_, _>>::evaluate(parameters, &chained_input)
+    }
+}
+
 impl<P, W> AllocVar<Parameters<P>, ConstraintF<P>> for ParametersVar<P, W>
 where
     P: TEModelParameters,
@@ -109,7 +147,7 @@ mod test {
     use ark_std::rand::Rng;
 
     use crate::crh::bowe_hopwood;
-    use crate::crh::pedersen;
+    use crate::crh::{pedersen, TwoToOneCRH, TwoToOneCRHGadget};
     use crate::{CRHGadget, CRH};
     use ark_ed_on_bls12_381::{constraints::FqVar, EdwardsParameters, Fq as Fr};
     use ark_r1cs_std::{alloc::AllocVar, uint8::UInt8, R1CSVar};
@@ -127,11 +165,12 @@ mod test {
         const NUM_WINDOWS: usize = 8;
     }
 
-    fn generate_input<R: Rng>(
+    fn generate_u8_input<R: Rng>(
         cs: ConstraintSystemRef<Fr>,
+        size: usize,
         rng: &mut R,
-    ) -> ([u8; 189], Vec<UInt8<Fr>>) {
-        let mut input = [1u8; 189];
+    ) -> (Vec<u8>, Vec<UInt8<Fr>>) {
+        let mut input = vec![1u8; size];
         rng.fill_bytes(&mut input);
 
         let mut input_bytes = vec![];
@@ -146,11 +185,11 @@ mod test {
         let rng = &mut test_rng();
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let (input, input_var) = generate_input(cs.clone(), rng);
+        let (input, input_var) = generate_u8_input(cs.clone(), 189, rng);
         println!("number of constraints for input: {}", cs.num_constraints());
 
-        let parameters = TestCRH::setup(rng).unwrap();
-        let primitive_result = TestCRH::evaluate(&parameters, &input).unwrap();
+        let parameters = <TestCRH as CRH>::setup(rng).unwrap();
+        let primitive_result = <TestCRH as CRH>::evaluate(&parameters, &input).unwrap();
 
         let parameters_var = <TestCRHGadget as CRHGadget<TestCRH, Fr>>::ParametersVar::new_witness(
             ark_relations::ns!(cs, "parameters_var"),
@@ -162,10 +201,43 @@ mod test {
             cs.num_constraints()
         );
 
-        let result_var = TestCRHGadget::evaluate(&parameters_var, &input_var).unwrap();
+        let result_var =
+            <TestCRHGadget as CRHGadget<TestCRH, Fr>>::evaluate(&parameters_var, &input_var)
+                .unwrap();
 
         println!("number of constraints total: {}", cs.num_constraints());
 
+        assert_eq!(primitive_result, result_var.value().unwrap());
+        assert!(cs.is_satisfied().unwrap());
+    }
+
+    #[test]
+    fn test_native_two_to_one_equality() {
+        let rng = &mut test_rng();
+        let cs = ConstraintSystem::<Fr>::new_ref();
+
+        // Max input size is 63 bytes. That leaves 31 for the left half, 31 for the right, and 1
+        // byte of padding.
+        let (left_input, left_input_var) = generate_u8_input(cs.clone(), 31, rng);
+        let (right_input, right_input_var) = generate_u8_input(cs.clone(), 31, rng);
+        let parameters = <TestCRH as TwoToOneCRH>::setup(rng).unwrap();
+        let primitive_result =
+            <TestCRH as TwoToOneCRH>::evaluate(&parameters, &left_input, &right_input).unwrap();
+
+        let parameters_var = <TestCRHGadget as CRHGadget<TestCRH, Fr>>::ParametersVar::new_witness(
+            ark_relations::ns!(cs, "parameters_var"),
+            || Ok(&parameters),
+        )
+        .unwrap();
+
+        let result_var = <TestCRHGadget as TwoToOneCRHGadget<_, _>>::evaluate(
+            &parameters_var,
+            &left_input_var,
+            &right_input_var,
+        )
+        .unwrap();
+
+        let primitive_result = primitive_result;
         assert_eq!(primitive_result, result_var.value().unwrap());
         assert!(cs.is_satisfied().unwrap());
     }

--- a/src/merkle_tree/constraints.rs
+++ b/src/merkle_tree/constraints.rs
@@ -85,7 +85,7 @@ where
     ConstraintF: Field,
 {
     /// Calculate the root of the Merkle tree assuming that `leaf` is the leaf on the path defined by `self`.
-    fn calculate_root(
+    pub fn calculate_root(
         &self,
         leaf_hash_params: &LeafH::ParametersVar,
         two_to_one_hash_params: &TwoToOneH::ParametersVar,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This implements `TwoToOneCRH` for Bowe-Hopwood. You can now use B-H over Jubjub for circuit land Merkle tree membership proofs.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (main)
- [X] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [X] Wrote unit tests
- [ ] Updated relevant documentation in the code (N/A)
- [X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
