### PR TITLE
Use `to_non_unique_bytes` in Merkle tree constraints

### DIFF
--- a/src/merkle_tree/constraints.rs
+++ b/src/merkle_tree/constraints.rs
@@ -91,7 +91,7 @@ where
         two_to_one_hash_params: &TwoToOneH::ParametersVar,
         leaf: &impl ToBytesGadget<ConstraintF>,
     ) -> Result<TwoToOneH::OutputVar, SynthesisError> {
-        let leaf_bytes = leaf.to_bytes_unchecked()?;
+        let leaf_bytes = leaf.to_non_unique_bytes()?;
         let claimed_leaf_hash = LeafH::evaluate(leaf_hash_params, &leaf_bytes)?;
         let leaf_sibling_hash = &self.leaf_sibling;
 
@@ -104,11 +104,11 @@ where
         let left_hash = self
             .leaf_is_right_child
             .select(leaf_sibling_hash, &claimed_leaf_hash)?
-            .to_bytes_unchecked()?;
+            .to_non_unique_bytes()?;
         let right_hash = self
             .leaf_is_right_child
             .select(&claimed_leaf_hash, leaf_sibling_hash)?
-            .to_bytes_unchecked()?;
+            .to_non_unique_bytes()?;
 
         let mut curr_hash = TwoToOneH::evaluate(two_to_one_hash_params, &left_hash, &right_hash)?;
         // To traverse up a MT, we iterate over the path from bottom to top (i.e. in reverse)
@@ -122,8 +122,8 @@ where
 
             curr_hash = TwoToOneH::evaluate(
                 two_to_one_hash_params,
-                &left_hash.to_bytes_unchecked()?,
-                &right_hash.to_bytes_unchecked()?,
+                &left_hash.to_non_unique_bytes()?,
+                &right_hash.to_non_unique_bytes()?,
             )?;
         }
 

--- a/src/merkle_tree/constraints.rs
+++ b/src/merkle_tree/constraints.rs
@@ -91,7 +91,7 @@ where
         two_to_one_hash_params: &TwoToOneH::ParametersVar,
         leaf: &impl ToBytesGadget<ConstraintF>,
     ) -> Result<TwoToOneH::OutputVar, SynthesisError> {
-        let leaf_bytes = leaf.to_bytes()?;
+        let leaf_bytes = leaf.to_bytes_unchecked()?;
         let claimed_leaf_hash = LeafH::evaluate(leaf_hash_params, &leaf_bytes)?;
         let leaf_sibling_hash = &self.leaf_sibling;
 
@@ -104,11 +104,11 @@ where
         let left_hash = self
             .leaf_is_right_child
             .select(leaf_sibling_hash, &claimed_leaf_hash)?
-            .to_bytes()?;
+            .to_bytes_unchecked()?;
         let right_hash = self
             .leaf_is_right_child
             .select(&claimed_leaf_hash, leaf_sibling_hash)?
-            .to_bytes()?;
+            .to_bytes_unchecked()?;
 
         let mut curr_hash = TwoToOneH::evaluate(two_to_one_hash_params, &left_hash, &right_hash)?;
         // To traverse up a MT, we iterate over the path from bottom to top (i.e. in reverse)
@@ -122,8 +122,8 @@ where
 
             curr_hash = TwoToOneH::evaluate(
                 two_to_one_hash_params,
-                &left_hash.to_bytes()?,
-                &right_hash.to_bytes()?,
+                &left_hash.to_bytes_unchecked()?,
+                &right_hash.to_bytes_unchecked()?,
             )?;
         }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

There are two ways to convert a field element to bytes: `to_bytes`, and `to_bytes_unchecked`. The former enforces that the bytes represent an integer whose value is less than the field modulus, while the latter does not (it only performs booleanity checks). While `to_bytes` is generally the preferred option because it provides safety checks by default, in the context of a Merkle tree it is inefficient to use it due to the additional check.

Rather, we can use `to_bytes_unchecked` here, because if the prover provides a bad bit-representation, the root of the Merkle tree will be different, which will cause the constraint system to fail.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (main)
- [X] have an explanation in the PR that describes this work.
- [X] Wrote unit tests (n/a)
- [X] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
