### PR TITLE
Fix `Clone` for Merkle Tree Path

### DIFF
--- a/src/merkle_tree/constraints.rs
+++ b/src/merkle_tree/constraints.rs
@@ -88,7 +88,8 @@ type TwoToOneParam<PG, P, ConstraintF> =
     >>::ParametersVar;
 
 /// Represents a merkle tree path gadget.
-#[derive(Debug)]
+#[derive(Debug, Derivative)]
+#[derivative(Clone(bound = "P: Config, ConstraintF: Field, PG: ConfigGadget<P, ConstraintF>"))]
 pub struct PathVar<P: Config, ConstraintF: Field, PG: ConfigGadget<P, ConstraintF>> {
     /// `path[i]` is 0 (false) iff ith non-leaf node from top to bottom is left.
     path: Vec<Boolean<ConstraintF>>,
@@ -98,20 +99,6 @@ pub struct PathVar<P: Config, ConstraintF: Field, PG: ConfigGadget<P, Constraint
     leaf_sibling: PG::LeafDigest,
     /// Is this leaf the right child?
     leaf_is_right_child: Boolean<ConstraintF>,
-}
-
-// we add `Clone` trait manually because `derive` will add unnecessary trait bound on `P` and `PG`
-impl<P: Config, ConstraintF: Field, PG: ConfigGadget<P, ConstraintF>> Clone
-    for PathVar<P, ConstraintF, PG>
-{
-    fn clone(&self) -> Self {
-        Self {
-            path: self.path.clone(),
-            auth_path: self.auth_path.clone(),
-            leaf_sibling: self.leaf_sibling.clone(),
-            leaf_is_right_child: self.leaf_is_right_child.clone(),
-        }
-    }
 }
 
 impl<P: Config, ConstraintF: Field, PG: ConfigGadget<P, ConstraintF>> AllocVar<Path<P>, ConstraintF>

--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -106,23 +106,14 @@ pub type LeafParam<P> = <<P as Config>::LeafHash as CRHScheme>::Parameters;
 ///    [I] J
 /// ```
 ///  Suppose we want to prove I, then `leaf_sibling_hash` is J, `auth_path` is `[C,D]`
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Derivative,CanonicalSerialize, CanonicalDeserialize)]
+#[derivative(Clone(bound = "P: Config"))]
 pub struct Path<P: Config> {
     pub leaf_sibling_hash: P::LeafDigest,
     /// The sibling of path node ordered from higher layer to lower layer (does not include root node).
     pub auth_path: Vec<P::InnerDigest>,
     /// stores the leaf index of the node
     pub leaf_index: usize,
-}
-
-impl<P: Config> Clone for Path<P> {
-    fn clone(&self) -> Self {
-        Self {
-            leaf_sibling_hash: self.leaf_sibling_hash.clone(),
-            auth_path: self.auth_path.clone(),
-            leaf_index: self.leaf_index,
-        }
-    }
 }
 
 impl<P: Config> Path<P> {

--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -106,7 +106,7 @@ pub type LeafParam<P> = <<P as Config>::LeafHash as CRHScheme>::Parameters;
 ///    [I] J
 /// ```
 ///  Suppose we want to prove I, then `leaf_sibling_hash` is J, `auth_path` is `[C,D]`
-#[derive(Derivative,CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(Clone(bound = "P: Config"))]
 pub struct Path<P: Config> {
     pub leaf_sibling_hash: P::LeafDigest,

--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -106,13 +106,23 @@ pub type LeafParam<P> = <<P as Config>::LeafHash as CRHScheme>::Parameters;
 ///    [I] J
 /// ```
 ///  Suppose we want to prove I, then `leaf_sibling_hash` is J, `auth_path` is `[C,D]`
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct Path<P: Config> {
     pub leaf_sibling_hash: P::LeafDigest,
     /// The sibling of path node ordered from higher layer to lower layer (does not include root node).
     pub auth_path: Vec<P::InnerDigest>,
     /// stores the leaf index of the node
     pub leaf_index: usize,
+}
+
+impl<P: Config> Clone for Path<P> {
+    fn clone(&self) -> Self {
+        Self {
+            leaf_sibling_hash: self.leaf_sibling_hash.clone(),
+            auth_path: self.auth_path.clone(),
+            leaf_index: self.leaf_index,
+        }
+    }
 }
 
 impl<P: Config> Path<P> {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

The `derive` of `Clone` trait for `Path<P>` doesn't work well, because it implicitly adds a trait bound `P: Copy`. In most cases, when `clone`ing a path, user might encounter the following compile error: 
```
the following trait bounds were not satisfied:
            `P: Clone`
            which is required by `ark_crypto_primitives::Path<P>: Clone`
```

This PR removes the `derive` and implements `Clone` trait ~~manually~~ using `Derivative` instead.  Also added `Clone` for constraint path. 


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
