### PR TITLE
Allow user to set leaf position for `PathVar`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,14 +93,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Rust (${{ matrix.rust }})
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: thumbv6m-none-eabi
           override: true
 
-      - name: Install Rust ARM64 (${{ matrix.rust }})
+      - name: Install Rust ARM64
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [\#59](https://github.com/arkworks-rs/crypto-primitives/pull/59) Implement `TwoToOneCRHScheme` for Bowe-Hopwood CRH.
 - [\#60](https://github.com/arkworks-rs/crypto-primitives/pull/60) Merkle tree no longer requires CRH to input and output bytes. Leaf can be any raw input of CRH, such as field elements.
 - [\#67](https://github.com/arkworks-rs/crypto-primitives/pull/67) User can access or replace leaf index variable in `PathVar`.
+
 ### Improvements
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - [\#59](https://github.com/arkworks-rs/crypto-primitives/pull/59) Implement `TwoToOneCRHScheme` for Bowe-Hopwood CRH.
 - [\#60](https://github.com/arkworks-rs/crypto-primitives/pull/60) Merkle tree no longer requires CRH to input and output bytes. Leaf can be any raw input of CRH, such as field elements.
-
+- [\#67](https://github.com/arkworks-rs/crypto-primitives/pull/67) User can access or replace leaf index variable in `PathVar`.
 ### Improvements
 
 ### Bug fixes

--- a/src/merkle_tree/constraints.rs
+++ b/src/merkle_tree/constraints.rs
@@ -156,9 +156,10 @@ impl<P: Config, ConstraintF: Field, PG: ConfigGadget<P, ConstraintF>> PathVar<P,
     pub fn set_leaf_position(&mut self, leaf_index: Vec<Boolean<ConstraintF>>) {
         // convert leaf_index to path:
         // first remove the element (which represent a leaf), pad it to appropriate length
-        // and reverse it to become big endian
+        // and reverse it to become big endian.
+        // Also, set `leaf_is_right_child` accordingly.
         let mut path = leaf_index;
-        let _ = path.remove(0);
+        let leaf_is_right_child = path.remove(0);
         // pad the path
         if path.len() < self.auth_path.len() {
             path.extend((0..self.auth_path.len() - path.len()).map(|_| Boolean::constant(false)))
@@ -166,6 +167,7 @@ impl<P: Config, ConstraintF: Field, PG: ConfigGadget<P, ConstraintF>> PathVar<P,
         path.truncate(self.auth_path.len());
         path.reverse();
         self.path = path;
+        self.leaf_is_right_child = leaf_is_right_child;
     }
 
     /// Calculate the root of the Merkle tree assuming that `leaf` is the leaf on the path defined by `self`.

--- a/src/merkle_tree/constraints.rs
+++ b/src/merkle_tree/constraints.rs
@@ -170,6 +170,13 @@ impl<P: Config, ConstraintF: Field, PG: ConfigGadget<P, ConstraintF>> PathVar<P,
         self.leaf_is_right_child = leaf_is_right_child;
     }
 
+    /// Return the leaf position index in little-endian form.
+    pub fn get_leaf_position(&self) -> Vec<Boolean<ConstraintF>> {
+        ark_std::iter::once(self.leaf_is_right_child.clone())
+            .chain(self.path.clone().into_iter().rev())
+            .collect()
+    }
+
     /// Calculate the root of the Merkle tree assuming that `leaf` is the leaf on the path defined by `self`.
     #[tracing::instrument(target = "r1cs", skip(self, leaf_params, two_to_one_params))]
     pub fn calculate_root(

--- a/src/merkle_tree/tests/constraints.rs
+++ b/src/merkle_tree/tests/constraints.rs
@@ -246,6 +246,7 @@ mod field_mt_tests {
     use crate::{CRHSchemeGadget, MerkleTree, PathVar};
     use ark_r1cs_std::alloc::AllocVar;
     use ark_r1cs_std::fields::fp::FpVar;
+    use ark_r1cs_std::uint32::UInt32;
     use ark_r1cs_std::R1CSVar;
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, One, UniformRand};
@@ -341,7 +342,7 @@ mod field_mt_tests {
             println!("constraints from leaf: {}", constraints_from_leaf);
 
             // Allocate MT Path
-            let cw = PathVar::<FieldMTConfig, F, FieldMTConfigVar>::new_witness(
+            let mut cw = PathVar::<FieldMTConfig, F, FieldMTConfigVar>::new_witness(
                 ark_relations::ns!(cs, "new_witness"),
                 || Ok(&proof),
             )
@@ -353,6 +354,12 @@ mod field_mt_tests {
                 - constraints_from_leaf;
             println!("constraints from path: {}", constraints_from_path);
             assert!(cs.is_satisfied().unwrap());
+
+            // specify the source of index
+            let leaf_pos = UInt32::new_witness(cs.clone(), || Ok(i as u32))
+                .unwrap()
+                .to_bits_le();
+            cw.set_leaf_position(leaf_pos);
 
             assert!(cw
                 .verify_membership(

--- a/src/merkle_tree/tests/constraints.rs
+++ b/src/merkle_tree/tests/constraints.rs
@@ -355,7 +355,7 @@ mod field_mt_tests {
             println!("constraints from path: {}", constraints_from_path);
             assert!(cs.is_satisfied().unwrap());
 
-            // specify the source of index
+            // try replace the path index
             let leaf_pos = UInt32::new_witness(cs.clone(), || Ok(i as u32))
                 .unwrap()
                 .to_bits_le();

--- a/src/merkle_tree/tests/constraints.rs
+++ b/src/merkle_tree/tests/constraints.rs
@@ -359,7 +359,13 @@ mod field_mt_tests {
             let leaf_pos = UInt32::new_witness(cs.clone(), || Ok(i as u32))
                 .unwrap()
                 .to_bits_le();
-            cw.set_leaf_position(leaf_pos);
+            cw.set_leaf_position(leaf_pos.clone());
+
+            // check if get_leaf_position is correct
+            let expected_leaf_pos = leaf_pos.value().unwrap();
+            let mut actual_leaf_pos = cw.get_leaf_position().value().unwrap();
+            actual_leaf_pos.extend((0..(32 - actual_leaf_pos.len())).map(|_| false));
+            assert_eq!(expected_leaf_pos, actual_leaf_pos);
 
             assert!(cw
                 .verify_membership(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Currently, for `PathVar`, the location information is encoded by `path: Vec<Boolean>` and `leaf_is_right_child: Boolean` (chaining those two get the big endian encoding of index of leaf). 

There are indeed many circumstances where we also have constraints on leaf position (take IOP verifier's query as an example). For now, `path` and `leaf_is_right_child` are just variables created from `Boolean::new_variable`, and user do not have access to such those variables. In this commit, user will be able to: 
- get the leaf index variable in `PathVar` and constrain them
- replace the leaf index variable in `PathVar` with their own variable (possibly already with some constraints)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
