### PR TITLE
forbid size 1 merkle tree

### DIFF
--- a/src/merkle_tree/mod.rs
+++ b/src/merkle_tree/mod.rs
@@ -257,8 +257,8 @@ impl<P: Config> MerkleTree<P> {
     ) -> Result<Self, crate::Error> {
         let leaf_nodes_size = leaves_digest.len();
         assert!(
-            leaf_nodes_size.is_power_of_two(),
-            "`leaves.len() should be power of two"
+            leaf_nodes_size.is_power_of_two() && leaf_nodes_size > 1,
+            "`leaves.len() should be power of two and greater than one"
         );
         let non_leaf_nodes_size = leaf_nodes_size - 1;
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

The current merkle tree code assumes that the merkle tree height is greater than 1 (has at least two leaves). Otherwise the code will panic: https://github.com/arkworks-rs/crypto-primitives/blob/main/src/merkle_tree/mod.rs#L352. 
While it is debatable whether the merkle tree should support size 1 merkle tree. The implementation should at least make this assumption explicit.

(for example, it will cause the problem like https://github.com/Manta-Network/manta-crypto/pull/23)
closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
