### PR TITLE
Implemented SHA-256 CRH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- Implemented SHA-256 CRH
+
 ### Breaking changes
 
 - [\#56](https://github.com/arkworks-rs/crypto-primitives/pull/56) Compress the output of the Bowe-Hopwood-Pedersen CRH to a single field element, in line with the Zcash specification.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ark-serialize = { version = "^0.3.0", default-features = false, features = [ "de
 ark-sponge = { version = "^0.3.0", default-features = false }
 
 blake2 = { version = "0.9", default-features = false }
+sha2 = { version = "0.9", default-features = false }
 digest = "0.9"
 
 ark-r1cs-std = { version = "^0.3.0", optional = true, default-features = false }

--- a/src/crh/mod.rs
+++ b/src/crh/mod.rs
@@ -7,6 +7,7 @@ pub mod bowe_hopwood;
 pub mod injective_map;
 pub mod pedersen;
 pub mod poseidon;
+pub mod sha256;
 
 use crate::Error;
 

--- a/src/crh/sha256/constraints.rs
+++ b/src/crh/sha256/constraints.rs
@@ -1,0 +1,270 @@
+// This file was adapted from
+// https://github.com/nanpuyue/sha256/blob/bf6656b7dc72e76bb617445a8865f906670e585b/src/lib.rs
+// See LICENSE-MIT in the root directory for a copy of the license
+// Thank you!
+
+use crate::crh::sha256::r1cs_utils::UInt32Ext;
+
+use core::iter;
+
+use ark_ff::PrimeField;
+use ark_r1cs_std::bits::{uint32::UInt32, uint8::UInt8};
+use ark_std::{vec, vec::Vec};
+
+const STATE_LEN: usize = 8;
+
+type State = [u32; STATE_LEN];
+
+const K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+const H: State = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
+
+#[derive(Clone)]
+pub struct Sha256Gadget<ConstraintF: PrimeField> {
+    state: Vec<UInt32<ConstraintF>>,
+    completed_data_blocks: u64,
+    pending: Vec<UInt8<ConstraintF>>,
+    num_pending: usize,
+}
+
+impl<ConstraintF: PrimeField> Default for Sha256Gadget<ConstraintF> {
+    fn default() -> Self {
+        Self {
+            state: H.iter().cloned().map(UInt32::constant).collect(),
+            completed_data_blocks: 0,
+            pending: iter::repeat(0u8).take(64).map(UInt8::constant).collect(),
+            num_pending: 0,
+        }
+    }
+}
+
+// Wikipedia's pseudocode is a good companion for understanding the below
+// https://en.wikipedia.org/wiki/SHA-2#Pseudocode
+impl<ConstraintF: PrimeField> Sha256Gadget<ConstraintF> {
+    fn update_state(state: &mut [UInt32<ConstraintF>], data: &[UInt8<ConstraintF>]) {
+        assert_eq!(data.len(), 64);
+
+        let mut w = vec![UInt32::constant(0); 64];
+        for (word, chunk) in w.iter_mut().zip(data.chunks(4)) {
+            *word = UInt32::from_be_bytes(chunk);
+        }
+
+        for i in 16..64 {
+            let s0 = {
+                let x1 = w[i - 15].rotr(7);
+                let x2 = w[i - 15].rotr(18);
+                let x3 = w[i - 15].shr(3);
+                x1.xor(&x2).unwrap().xor(&x3).unwrap()
+            };
+            let s1 = {
+                let x1 = w[i - 2].rotr(17);
+                let x2 = w[i - 2].rotr(19);
+                let x3 = w[i - 2].shr(10);
+                x1.xor(&x2).unwrap().xor(&x3).unwrap()
+            };
+            w[i] = UInt32::addmany(&[w[i - 16].clone(), s0, w[i - 7].clone(), s1]).unwrap();
+        }
+
+        let mut h = state.to_vec();
+        for i in 0..64 {
+            let ch = {
+                let x1 = h[4].bitand(&h[5]);
+                let x2 = h[4].not().bitand(&h[6]);
+                x1.xor(&x2).unwrap()
+            };
+            let ma = {
+                let x1 = h[0].bitand(&h[1]);
+                let x2 = h[0].bitand(&h[2]);
+                let x3 = h[1].bitand(&h[2]);
+                x1.xor(&x2).unwrap().xor(&x3).unwrap()
+            };
+            let s0 = {
+                let x1 = h[0].rotr(2);
+                let x2 = h[0].rotr(13);
+                let x3 = h[0].rotr(22);
+                x1.xor(&x2).unwrap().xor(&x3).unwrap()
+            };
+            let s1 = {
+                let x1 = h[4].rotr(6);
+                let x2 = h[4].rotr(11);
+                let x3 = h[4].rotr(25);
+                x1.xor(&x2).unwrap().xor(&x3).unwrap()
+            };
+            let t0 = UInt32::addmany(&[h[7].clone(), s1, ch, UInt32::constant(K[i]), w[i].clone()])
+                .unwrap();
+            let t1 = UInt32::addmany(&[s0, ma]).unwrap();
+
+            h[7] = h[6].clone();
+            h[6] = h[5].clone();
+            h[5] = h[4].clone();
+            h[4] = UInt32::addmany(&[h[3].clone(), t0.clone()]).unwrap();
+            h[3] = h[2].clone();
+            h[2] = h[1].clone();
+            h[1] = h[0].clone();
+            h[0] = UInt32::addmany(&[t0, t1]).unwrap();
+        }
+
+        for (s, hi) in state.iter_mut().zip(h.iter()) {
+            *s = UInt32::addmany(&[s.clone(), hi.clone()]).unwrap();
+        }
+    }
+
+    /// Consumes the given data and updates the internal state
+    pub fn update(&mut self, data: &[UInt8<ConstraintF>]) {
+        let mut offset = 0;
+        if self.num_pending > 0 && self.num_pending + data.len() >= 64 {
+            offset = 64 - self.num_pending;
+            // If the inputted data pushes the pending buffer over the chunk size, process it all
+            self.pending[self.num_pending..].clone_from_slice(&data[..offset]);
+            Self::update_state(&mut self.state, &self.pending);
+
+            self.completed_data_blocks += 1;
+            self.num_pending = 0;
+        }
+
+        for chunk in data[offset..].chunks(64) {
+            let chunk_size = chunk.len();
+
+            if chunk_size == 64 {
+                // If it's a full chunk, process it
+                Self::update_state(&mut self.state, chunk);
+                self.completed_data_blocks += 1;
+            } else {
+                // Otherwise, add the bytes to the `pending` buffer
+                self.pending[self.num_pending..self.num_pending + chunk_size]
+                    .clone_from_slice(chunk);
+                self.num_pending += chunk_size;
+            }
+        }
+    }
+
+    /// Outputs the final digest of all the inputted data
+    pub fn finalize(mut self) -> Vec<UInt8<ConstraintF>> {
+        // Encode the number of processed bits as a u64, then serialize it to 8 big-endian bytes
+        let data_bitlen = self.completed_data_blocks * 512 + self.num_pending as u64 * 8;
+        let encoded_bitlen: Vec<UInt8<ConstraintF>> = {
+            let bytes = data_bitlen.to_be_bytes();
+            bytes.iter().map(|&b| UInt8::constant(b)).collect()
+        };
+
+        // Padding starts with a 1 followed by some number of zeros (0x80 = 0b10000000)
+        let mut pending = vec![UInt8::constant(0); 72];
+        pending[0] = UInt8::constant(0x80);
+
+        // We'll either append to the 56+8 = 64 byte boundary or the 120+8 = 128 byte boundary,
+        // depending on whether we have at least 56 unprocessed bytes
+        let offset = if self.num_pending < 56 {
+            56 - self.num_pending
+        } else {
+            120 - self.num_pending
+        };
+
+        // Write the bitlen to the end of the padding. Then process all the padding
+        pending[offset..offset + 8].clone_from_slice(&encoded_bitlen);
+        self.update(&pending[..offset + 8]);
+
+        // Collect the state into big-endian bytes
+        self.state.iter().flat_map(UInt32::to_be_bytes).collect()
+    }
+
+    /// Computes the digest of the given data. This is a shortcut for `default()` followed by
+    /// `update()` followed by `finalize()`.
+    pub fn digest(data: &[UInt8<ConstraintF>]) -> Vec<UInt8<ConstraintF>> {
+        let mut sha256_var = Self::default();
+        sha256_var.update(data);
+        sha256_var.finalize()
+    }
+}
+
+// All the tests below test against the RustCrypto sha2 implementation
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::crh::sha256::{digest::Digest, Sha256};
+
+    use ark_bls12_377::Fr;
+    use ark_r1cs_std::R1CSVar;
+    use ark_relations::{
+        ns,
+        r1cs::{ConstraintSystem, Namespace},
+    };
+    use ark_std::rand::RngCore;
+
+    /// Witnesses bytes
+    fn to_byte_vars(cs: impl Into<Namespace<Fr>>, data: &[u8]) -> Vec<UInt8<Fr>> {
+        let cs = cs.into().cs();
+        UInt8::new_witness_vec(cs, data).unwrap()
+    }
+
+    /// Finalizes a SHA256 gadget and gets the bytes
+    fn finalize_var(sha256_var: Sha256Gadget<Fr>) -> Vec<u8> {
+        sha256_var
+            .finalize()
+            .into_iter()
+            .map(|b| b.value().unwrap())
+            .collect()
+    }
+
+    /// Finalizes a native SHA256 struct and gets the bytes
+    fn finalize(sha256: Sha256) -> Vec<u8> {
+        sha256.finalize().to_vec()
+    }
+
+    /// Tests the SHA256 of random strings of all lengths from 0 to 100
+    #[test]
+    fn varied_lengths() {
+        let mut rng = ark_std::test_rng();
+        let cs = ConstraintSystem::<Fr>::new_ref();
+
+        for i in 0..=100 {
+            let mut sha256 = Sha256::default();
+            let mut sha256_var = Sha256Gadget::default();
+
+            // Make a random string of length i
+            let mut input_str = vec![0u8; i];
+            rng.fill_bytes(&mut input_str);
+
+            // Compute the hashes and assert consistency
+            sha256_var.update(&to_byte_vars(ns!(cs, "input"), &input_str));
+            sha256.update(input_str);
+            assert_eq!(
+                finalize_var(sha256_var),
+                finalize(sha256),
+                "error at length {}",
+                i
+            );
+        }
+    }
+
+    /// Calls `update()` many times
+    #[test]
+    fn many_updates() {
+        let mut rng = ark_std::test_rng();
+        let cs = ConstraintSystem::<Fr>::new_ref();
+        let mut sha256 = Sha256::default();
+        let mut sha256_var = Sha256Gadget::default();
+
+        // Append the same 7-byte string 128 times
+        for _ in 0..128 {
+            let mut input_str = vec![0u8; 7];
+            rng.fill_bytes(&mut input_str);
+
+            sha256_var.update(&to_byte_vars(ns!(cs, "input"), &input_str));
+            sha256.update(input_str);
+        }
+
+        // Make sure the result is consistent
+        assert_eq!(finalize_var(sha256_var), finalize(sha256));
+    }
+}

--- a/src/crh/sha256/mod.rs
+++ b/src/crh/sha256/mod.rs
@@ -1,0 +1,81 @@
+use crate::crh::{CRHScheme, TwoToOneCRHScheme};
+use crate::{Error, Vec};
+
+use ark_std::rand::Rng;
+
+// Re-export the RustCrypto Sha256 type and its associated traits
+pub use sha2::{digest, Sha256};
+
+#[cfg(feature = "r1cs")]
+mod r1cs_utils;
+
+#[cfg(feature = "r1cs")]
+pub mod constraints;
+
+// Implement the CRH traits for SHA-256
+
+use core::borrow::Borrow;
+use sha2::digest::Digest;
+
+impl CRHScheme for Sha256 {
+    type Input = [u8];
+    // This is always 32 bytes. It has to be a Vec to impl CanonicalSerialize
+    type Output = Vec<u8>;
+    // There are no parameters for SHA256
+    type Parameters = ();
+
+    // There are no parameters for SHA256
+    fn setup<R: Rng>(_rng: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(())
+    }
+
+    // Evaluates SHA256(input)
+    fn evaluate<T: Borrow<Self::Input>>(
+        _parameters: &Self::Parameters,
+        input: T,
+    ) -> Result<Self::Output, Error> {
+        Ok(Sha256::digest(input.borrow()).to_vec())
+    }
+}
+
+impl TwoToOneCRHScheme for Sha256 {
+    type Input = [u8];
+    // This is always 32 bytes. It has to be a Vec to impl CanonicalSerialize
+    type Output = Vec<u8>;
+    // There are no parameters for SHA256
+    type Parameters = ();
+
+    // There are no parameters for SHA256
+    fn setup<R: Rng>(_rng: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(())
+    }
+
+    // Evaluates SHA256(left_input || right_input)
+    fn evaluate<T: Borrow<Self::Input>>(
+        _parameters: &Self::Parameters,
+        left_input: T,
+        right_input: T,
+    ) -> Result<Self::Output, Error> {
+        let left_input = left_input.borrow();
+        let right_input = right_input.borrow();
+
+        // Process the left input then the right input
+        let mut h = Sha256::default();
+        h.update(left_input);
+        h.update(right_input);
+        Ok(h.finalize().to_vec())
+    }
+
+    // Evaluates SHA256(left_input || right_input)
+    fn compress<T: Borrow<Self::Output>>(
+        parameters: &Self::Parameters,
+        left_input: T,
+        right_input: T,
+    ) -> Result<Self::Output, Error> {
+        <Self as TwoToOneCRHScheme>::evaluate(
+            parameters,
+            left_input.borrow().as_slice(),
+            right_input.borrow().as_slice(),
+        )
+    }
+}

--- a/src/crh/sha256/r1cs_utils.rs
+++ b/src/crh/sha256/r1cs_utils.rs
@@ -1,9 +1,10 @@
 use ark_ff::PrimeField;
 use ark_r1cs_std::bits::{boolean::Boolean, uint32::UInt32, uint8::UInt8, ToBitsGadget};
+use ark_relations::r1cs::SynthesisError;
 use core::iter;
 
 /// Extra traits not automatically implemented by UInt32
-pub(crate) trait UInt32Ext<ConstraintF: PrimeField> {
+pub(crate) trait UInt32Ext<ConstraintF: PrimeField>: Sized {
     /// Right shift
     fn shr(&self, by: usize) -> Self;
 
@@ -11,13 +12,13 @@ pub(crate) trait UInt32Ext<ConstraintF: PrimeField> {
     fn not(&self) -> Self;
 
     /// Bitwise AND
-    fn bitand(&self, rhs: &Self) -> Self;
+    fn bitand(&self, rhs: &Self) -> Result<Self, SynthesisError>;
 
     /// Converts from big-endian bytes
-    fn from_be_bytes(bytes: &[UInt8<ConstraintF>]) -> Self;
+    fn from_bytes_be(bytes: &[UInt8<ConstraintF>]) -> Result<Self, SynthesisError>;
 
     /// Converts to big-endian bytes
-    fn to_be_bytes(&self) -> Vec<UInt8<ConstraintF>>;
+    fn to_bytes_be(&self) -> Vec<UInt8<ConstraintF>>;
 }
 
 impl<ConstraintF: PrimeField> UInt32Ext<ConstraintF> for UInt32<ConstraintF> {
@@ -39,28 +40,28 @@ impl<ConstraintF: PrimeField> UInt32Ext<ConstraintF> for UInt32<ConstraintF> {
         UInt32::from_bits_le(&new_bits)
     }
 
-    fn bitand(&self, rhs: &Self) -> Self {
-        let new_bits: Vec<_> = self
+    fn bitand(&self, rhs: &Self) -> Result<Self, SynthesisError> {
+        let new_bits: Result<Vec<_>, SynthesisError> = self
             .to_bits_le()
             .into_iter()
             .zip(rhs.to_bits_le().into_iter())
-            .map(|(a, b)| a.and(&b).unwrap())
+            .map(|(a, b)| a.and(&b))
             .collect();
-        UInt32::from_bits_le(&new_bits)
+        Ok(UInt32::from_bits_le(&new_bits?))
     }
 
-    fn from_be_bytes(bytes: &[UInt8<ConstraintF>]) -> Self {
+    fn from_bytes_be(bytes: &[UInt8<ConstraintF>]) -> Result<Self, SynthesisError> {
         assert_eq!(bytes.len(), 4);
 
-        let bits: Vec<_> = bytes
-            .iter()
-            .rev()
-            .flat_map(|b| b.to_bits_le().unwrap())
-            .collect();
-        UInt32::from_bits_le(&bits)
+        let mut bits: Vec<Boolean<ConstraintF>> = Vec::new();
+        for byte in bytes.iter().rev() {
+            let b: Vec<Boolean<ConstraintF>> = byte.to_bits_le()?;
+            bits.extend(b);
+        }
+        Ok(UInt32::from_bits_le(&bits))
     }
 
-    fn to_be_bytes(&self) -> Vec<UInt8<ConstraintF>> {
+    fn to_bytes_be(&self) -> Vec<UInt8<ConstraintF>> {
         self.to_bits_le()
             .chunks(8)
             .rev()
@@ -98,6 +99,7 @@ mod test {
             assert_eq!(
                 UInt32::<Fr>::constant(x)
                     .bitand(&UInt32::constant(y))
+                    .unwrap()
                     .value()
                     .unwrap(),
                 x & y
@@ -106,12 +108,12 @@ mod test {
     }
 
     #[test]
-    fn test_to_from_be_bytes() {
+    fn test_to_from_bytes_be() {
         let mut rng = ark_std::test_rng();
         for _ in 0..NUM_TESTS {
             let x = UInt32::<Fr>::constant(rng.gen::<u32>());
-            let bytes = x.to_be_bytes();
-            let y = UInt32::from_be_bytes(&bytes);
+            let bytes = x.to_bytes_be();
+            let y = UInt32::from_bytes_be(&bytes).unwrap();
             assert_eq!(x.value(), y.value());
         }
     }

--- a/src/crh/sha256/r1cs_utils.rs
+++ b/src/crh/sha256/r1cs_utils.rs
@@ -1,0 +1,118 @@
+use ark_ff::PrimeField;
+use ark_r1cs_std::bits::{boolean::Boolean, uint32::UInt32, uint8::UInt8, ToBitsGadget};
+use core::iter;
+
+/// Extra traits not automatically implemented by UInt32
+pub(crate) trait UInt32Ext<ConstraintF: PrimeField> {
+    /// Right shift
+    fn shr(&self, by: usize) -> Self;
+
+    /// Bitwise NOT
+    fn not(&self) -> Self;
+
+    /// Bitwise AND
+    fn bitand(&self, rhs: &Self) -> Self;
+
+    /// Converts from big-endian bytes
+    fn from_be_bytes(bytes: &[UInt8<ConstraintF>]) -> Self;
+
+    /// Converts to big-endian bytes
+    fn to_be_bytes(&self) -> Vec<UInt8<ConstraintF>>;
+}
+
+impl<ConstraintF: PrimeField> UInt32Ext<ConstraintF> for UInt32<ConstraintF> {
+    fn shr(&self, by: usize) -> Self {
+        assert!(by < 32);
+
+        let zeros = iter::repeat(Boolean::constant(false)).take(by);
+        let new_bits: Vec<_> = self
+            .to_bits_le()
+            .into_iter()
+            .skip(by)
+            .chain(zeros)
+            .collect();
+        UInt32::from_bits_le(&new_bits)
+    }
+
+    fn not(&self) -> Self {
+        let new_bits: Vec<_> = self.to_bits_le().iter().map(Boolean::not).collect();
+        UInt32::from_bits_le(&new_bits)
+    }
+
+    fn bitand(&self, rhs: &Self) -> Self {
+        let new_bits: Vec<_> = self
+            .to_bits_le()
+            .into_iter()
+            .zip(rhs.to_bits_le().into_iter())
+            .map(|(a, b)| a.and(&b).unwrap())
+            .collect();
+        UInt32::from_bits_le(&new_bits)
+    }
+
+    fn from_be_bytes(bytes: &[UInt8<ConstraintF>]) -> Self {
+        assert_eq!(bytes.len(), 4);
+
+        let bits: Vec<_> = bytes
+            .iter()
+            .rev()
+            .flat_map(|b| b.to_bits_le().unwrap())
+            .collect();
+        UInt32::from_bits_le(&bits)
+    }
+
+    fn to_be_bytes(&self) -> Vec<UInt8<ConstraintF>> {
+        self.to_bits_le()
+            .chunks(8)
+            .rev()
+            .map(UInt8::from_bits_le)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use ark_bls12_377::Fr;
+    use ark_r1cs_std::{bits::uint32::UInt32, R1CSVar};
+    use ark_std::rand::Rng;
+
+    const NUM_TESTS: usize = 10_000;
+
+    #[test]
+    fn test_shr() {
+        let mut rng = ark_std::test_rng();
+        for _ in 0..NUM_TESTS {
+            let x = rng.gen::<u32>();
+            let by = rng.gen::<usize>() % 32;
+            assert_eq!(UInt32::<Fr>::constant(x).shr(by).value().unwrap(), x >> by);
+        }
+    }
+
+    #[test]
+    fn test_bitand() {
+        let mut rng = ark_std::test_rng();
+        for _ in 0..NUM_TESTS {
+            let x = rng.gen::<u32>();
+            let y = rng.gen::<u32>();
+            assert_eq!(
+                UInt32::<Fr>::constant(x)
+                    .bitand(&UInt32::constant(y))
+                    .value()
+                    .unwrap(),
+                x & y
+            );
+        }
+    }
+
+    #[test]
+    fn test_to_from_be_bytes() {
+        let mut rng = ark_std::test_rng();
+        for _ in 0..NUM_TESTS {
+            let x = UInt32::<Fr>::constant(rng.gen::<u32>());
+            let bytes = x.to_be_bytes();
+            let y = UInt32::from_be_bytes(&bytes);
+            assert_eq!(x.value(), y.value());
+        }
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

I implemented the SHA-256 hash function using [this native implementation](https://github.com/nanpuyue/sha256/blob/bf6656b7dc72e76bb617445a8865f906670e585b/src/lib.rs) as a starting point. Unit tests are written against the RustCrypto sha256 implementation.

Besides the standard `update()` and `finalize()` operations, this also implements the CRH traits both natively and in circuit-land.

Two things that I have questions about:
* The `CRHScheme::Output` for `Sha256` is `Vec<u8>` rather than `[u8; 32]`. The reason for this is because the compiler complains about not implementing `CanonicalSerialize` and `CanonicalDeserialize` otherwise. I think this is fixed in the next version of `ark-serialize`, so we might just want to leave this and update it when v0.4 comes around.
* SHA256 is not parameterized by anything, so I set the `CRHScheme::ParametersVar` to `()`. However, it's unclear what the appropriate thing to set `CRHSchemeGadget::ParametersVar` to is. I should be the Var equivalent to the unit type. To that end, I made my own `UnitVar` type that impls `AllocaVar`. If this duplicates something from elsewhere, let me know and I'll just use that functionality.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (main)
- [X] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [X] Wrote unit tests
- [X] Updated relevant documentation in the code
- [X] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
