### PR TITLE
Fixed SHA256 digest EqGadget bug; included regression test

### DIFF
--- a/src/crh/sha256/constraints.rs
+++ b/src/crh/sha256/constraints.rs
@@ -209,7 +209,7 @@ impl<ConstraintF: PrimeField> Sha256Gadget<ConstraintF> {
 
 /// Contains a 32-byte SHA256 digest
 #[derive(Clone, Debug)]
-pub struct DigestVar<ConstraintF: PrimeField>(Vec<UInt8<ConstraintF>>);
+pub struct DigestVar<ConstraintF: PrimeField>(pub Vec<UInt8<ConstraintF>>);
 
 impl<ConstraintF> EqGadget<ConstraintF> for DigestVar<ConstraintF>
 where


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fixes a bug in the `EqGadget` implementation of `crh::sha256::DigestVar`. I wrote a regression test that demonstrates the bug.

Didn't bother adding a changelog entry because the SHA256 entry is still pending. You can think of this as part of that.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (main)
- [X] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [X] Wrote unit tests
- [X] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
