### PR TITLE
Fix the dependency of ark-sponge in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,6 @@ ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves" }
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves" }
 ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves" }
 ark-mnt6-298 = { git = "https://github.com/arkworks-rs/curves" }
-ark-sponge = { git = "https://github.com/arkworks-rs/sponge", branch = "update-serialize" }
+ark-sponge = { git = "https://github.com/arkworks-rs/sponge" }
 ark-relations = {git = "https://github.com/arkworks-rs/snark", branch = "sync-algebra" }
 ark-snark = { git = "https://github.com/arkworks-rs/snark", branch = "sync-algebra" }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Since a PR in ark-sponge is merged and the corresponding branch is deleted, Cargo.toml is no longer able to find that branch. This PR fixes so.

Closes #82

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
