### PR TITLE
Impl `CanonicalSerialize` and `CanonicalDeserialize` for `pedersen::Parameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- [\#107](https://github.com/arkworks-rs/crypto-primitives/pull/107) Impl `CanonicalSerialize` and `CanonicalDeserialize` for `ark_crypto_primitives::crh::pedersen::Parameters`
+
 ### Improvements
 
 ### Bugfixes

--- a/src/crh/pedersen/mod.rs
+++ b/src/crh/pedersen/mod.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use crate::crh::{CRHScheme, TwoToOneCRHScheme};
 use ark_ec::CurveGroup;
 use ark_ff::{Field, ToConstraintField};
-use ark_serialize::CanonicalSerialize;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
 use ark_std::borrow::Borrow;
 use ark_std::cfg_chunks;
 
@@ -22,7 +22,7 @@ pub trait Window: Clone {
     const NUM_WINDOWS: usize;
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Parameters<C: CurveGroup> {
     pub generators: Vec<Vec<C>>,
 }

--- a/src/crh/pedersen/mod.rs
+++ b/src/crh/pedersen/mod.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use crate::crh::{CRHScheme, TwoToOneCRHScheme};
 use ark_ec::CurveGroup;
 use ark_ff::{Field, ToConstraintField};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::borrow::Borrow;
 use ark_std::cfg_chunks;
 


### PR DESCRIPTION
Two-line change. I have a `write_to_file<S: CanonicalSerialize>(filename: &Path, data: &S)` function, but I can't use it with Pedersen parameters. This fixes that problem.