### PR TITLE
Fix comment that does not match the code

### DIFF
--- a/src/sponge/absorb.rs
+++ b/src/sponge/absorb.rs
@@ -65,7 +65,7 @@ pub trait Absorb {
         }
     }
 
-    /// Specifies the conversion into a list of field elements for a batch. Append the list to `dest`.
+    /// Specifies the conversion into a list of field elements for a batch. Return the list as `Vec`.
     fn batch_to_sponge_field_elements_as_vec<F: PrimeField>(batch: &[Self]) -> Vec<F>
     where
         Self: Sized,


### PR DESCRIPTION
## Description

Fix the comment that does not match the code in `src/sponge/absorb.rs` line 68:
"Append the list to `dest`." -> "Return the list as `Vec`."

As the function `batch_to_sponge_field_elements_as_vec` returns `Vec`, 
the changed comment is more appropriate.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (comment line doesn't need a unit test)
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` (It doesn't need a change log, because it is not a significant change)
- [x] Re-reviewed `Files changed` in the Github PR explorer
