### PR TITLE
Fix bug in `Absorb` and update `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,8 +121,8 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-poly = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
 
-ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves/" }
-ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves/" }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves/" }
-ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves/" }
-ark-mnt6-298 = { git = "https://github.com/arkworks-rs/curves/" }
+ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-bls12-377 = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-mnt4-298 = { git = "https://github.com/arkworks-rs/algebra/" }
+ark-mnt6-298 = { git = "https://github.com/arkworks-rs/algebra/" }

--- a/src/sponge/absorb.rs
+++ b/src/sponge/absorb.rs
@@ -154,7 +154,7 @@ impl<P: FpConfig<N>, const N: usize> Absorb for Fp<P, N> {
         self.serialize_compressed(dest).unwrap()
     }
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
-        let _ = field_cast(&[*self], dest);
+        let _ = field_cast(&[*self], dest).unwrap();
     }
     fn batch_to_sponge_field_elements<F: PrimeField>(batch: &[Self], dest: &mut Vec<F>)
     where


### PR DESCRIPTION
With the current implementation of Poseidon, when trying to absorb a field element from a different field of sponge, there is no error and the developer would think everything is right :) The `unwrap` helps with making panics.

Also, I changed the repos from `curves` to `algebra`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
