### PR TITLE
Fix CI and build for each feature 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,5 +118,5 @@ jobs:
 
       - name: crypto-primitives
         run: |
-          cargo build --no-default-features --features=r1cs --target aarch64-unknown-none
-          cargo check --examples --no-default-features --features=r1cs --target aarch64-unknown-none
+          cargo build --no-default-features --features=r1cs,merkle_tree,prf,encryption,signature,snark --target aarch64-unknown-none
+          cargo check --all --no-default-features --features=r1cs,merkle_tree,prf,encryption,signature,snark --target aarch64-unknown-none

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -33,6 +33,7 @@ ark-snark = { version = "^0.4.0", default-features = false }
 rayon = { version = "1.0", optional = true }
 derivative = { version = "2.0", features = ["use_core"] }
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
+hashbrown = { version = "^0.14", default-features = false, optional = true }
 
 [features]
 default = ["std"]
@@ -43,7 +44,7 @@ r1cs = [ "ark-r1cs-std", "tracing" ]
 crh = [ "sponge" ]
 sponge = []
 commitment = ["crh"]
-merkle_tree = ["crh"]
+merkle_tree = ["crh", "hashbrown"]
 encryption = []
 prf = []
 snark = []

--- a/crypto-primitives/src/commitment/pedersen/mod.rs
+++ b/crypto-primitives/src/commitment/pedersen/mod.rs
@@ -4,6 +4,8 @@ use ark_ff::{BitIteratorLE, Field, PrimeField, ToConstraintField};
 use ark_serialize::CanonicalSerialize;
 use ark_std::marker::PhantomData;
 use ark_std::rand::Rng;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 use ark_std::UniformRand;
 
 use super::CommitmentScheme;

--- a/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
@@ -10,6 +10,8 @@ use crate::crh::{
 use ark_ff::Field;
 use ark_r1cs_std::{groups::curves::twisted_edwards::AffineVar, prelude::*};
 use ark_relations::r1cs::{Namespace, SynthesisError};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 use crate::crh::bowe_hopwood::{TwoToOneCRH, CRH};
 

--- a/crypto-primitives/src/crh/bowe_hopwood/mod.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/mod.rs
@@ -21,6 +21,8 @@ use ark_ff::fields::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::borrow::Borrow;
 use ark_std::cfg_chunks;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 use ark_std::UniformRand;
 
 #[cfg(feature = "r1cs")]

--- a/crypto-primitives/src/crh/injective_map/mod.rs
+++ b/crypto-primitives/src/crh/injective_map/mod.rs
@@ -1,5 +1,7 @@
 use crate::Error;
 use ark_std::rand::Rng;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 use ark_std::{fmt::Debug, hash::Hash, marker::PhantomData};
 
 use super::{pedersen, CRHScheme, TwoToOneCRHScheme};

--- a/crypto-primitives/src/crh/pedersen/constraints.rs
+++ b/crypto-primitives/src/crh/pedersen/constraints.rs
@@ -6,6 +6,8 @@ use ark_ec::CurveGroup;
 use ark_ff::Field;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::{Namespace, SynthesisError};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 use crate::crh::pedersen::{TwoToOneCRH, CRH};
 use crate::crh::{CRHSchemeGadget, TwoToOneCRHSchemeGadget};

--- a/crypto-primitives/src/crh/pedersen/mod.rs
+++ b/crypto-primitives/src/crh/pedersen/mod.rs
@@ -13,6 +13,8 @@ use ark_ff::{Field, ToConstraintField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::borrow::Borrow;
 use ark_std::cfg_chunks;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/crh/poseidon/constraints.rs
+++ b/crypto-primitives/src/crh/poseidon/constraints.rs
@@ -15,6 +15,8 @@ use ark_r1cs_std::R1CSVar;
 use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_std::borrow::Borrow;
 use ark_std::marker::PhantomData;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 #[derive(Clone)]
 pub struct CRHParametersVar<F: PrimeField + Absorb> {

--- a/crypto-primitives/src/crh/sha256/constraints.rs
+++ b/crypto-primitives/src/crh/sha256/constraints.rs
@@ -19,6 +19,8 @@ use ark_r1cs_std::{
     R1CSVar,
 };
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 const STATE_LEN: usize = 8;
 

--- a/crypto-primitives/src/crh/sha256/mod.rs
+++ b/crypto-primitives/src/crh/sha256/mod.rs
@@ -2,6 +2,8 @@ use crate::crh::{CRHScheme, TwoToOneCRHScheme};
 use crate::Error;
 
 use ark_std::rand::Rng;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 // Re-export the RustCrypto Sha256 type and its associated traits
 pub use sha2::{digest, Sha256};

--- a/crypto-primitives/src/encryption/elgamal/constraints.rs
+++ b/crypto-primitives/src/encryption/elgamal/constraints.rs
@@ -12,6 +12,8 @@ use ark_ff::{
 };
 use ark_serialize::CanonicalSerialize;
 use ark_std::{borrow::Borrow, marker::PhantomData};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 pub type ConstraintF<C> = <<C as CurveGroup>::BaseField as Field>::BasePrimeField;
 

--- a/crypto-primitives/src/merkle_tree/constraints.rs
+++ b/crypto-primitives/src/merkle_tree/constraints.rs
@@ -6,6 +6,8 @@ use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_std::borrow::Borrow;
 use ark_std::fmt::Debug;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 pub trait DigestVarConverter<From, To: ?Sized> {
     type TargetType: Borrow<To>;

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -6,8 +6,11 @@ use crate::sponge::Absorb;
 use crate::{crh::CRHScheme, Error};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::borrow::Borrow;
-use ark_std::collections::{BTreeSet, HashMap};
+use ark_std::collections::BTreeSet;
 use ark_std::hash::Hash;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
+use hashbrown::HashMap;
 
 #[cfg(test)]
 mod tests;

--- a/crypto-primitives/src/prf/blake2s/constraints.rs
+++ b/crypto-primitives/src/prf/blake2s/constraints.rs
@@ -3,6 +3,8 @@ use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
 
 use crate::prf::PRFGadget;
 use ark_r1cs_std::prelude::*;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 use core::borrow::Borrow;
 

--- a/crypto-primitives/src/prf/blake2s/mod.rs
+++ b/crypto-primitives/src/prf/blake2s/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 use blake2::{Blake2s256 as B2s, Blake2sMac};
 use digest::Digest;
 

--- a/crypto-primitives/src/prf/constraints.rs
+++ b/crypto-primitives/src/prf/constraints.rs
@@ -5,6 +5,8 @@ use crate::prf::PRF;
 use ark_relations::r1cs::{Namespace, SynthesisError};
 
 use ark_r1cs_std::prelude::*;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 pub trait PRFGadget<P: PRF, F: Field> {
     type OutputVar: EqGadget<F>

--- a/crypto-primitives/src/signature/schnorr/constraints.rs
+++ b/crypto-primitives/src/signature/schnorr/constraints.rs
@@ -5,7 +5,9 @@ use ark_relations::r1cs::{Namespace, SynthesisError};
 
 use crate::signature::SigRandomizePkGadget;
 
-use core::{borrow::Borrow, marker::PhantomData};
+use ark_std::{borrow::Borrow, marker::PhantomData};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 use crate::signature::schnorr::{Parameters, PublicKey, Schnorr};
 use digest::Digest;

--- a/crypto-primitives/src/signature/schnorr/mod.rs
+++ b/crypto-primitives/src/signature/schnorr/mod.rs
@@ -7,6 +7,8 @@ use ark_ff::{
 use ark_serialize::CanonicalSerialize;
 use ark_std::ops::Mul;
 use ark_std::rand::Rng;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 use ark_std::{hash::Hash, marker::PhantomData};
 use digest::Digest;
 

--- a/crypto-primitives/src/snark/constraints.rs
+++ b/crypto-primitives/src/snark/constraints.rs
@@ -16,6 +16,8 @@ use ark_relations::{
 };
 use ark_snark::{CircuitSpecificSetupSNARK, UniversalSetupSNARK, SNARK};
 use ark_std::{borrow::Borrow, fmt, marker::PhantomData, vec::IntoIter};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 /// This implements constraints for SNARK verifiers.
 pub trait SNARKGadget<F: PrimeField, ConstraintF: PrimeField, S: SNARK<F>> {

--- a/crypto-primitives/src/sponge/absorb.rs
+++ b/crypto-primitives/src/sponge/absorb.rs
@@ -7,6 +7,8 @@ use ark_ec::{
 use ark_ff::models::{Fp, FpConfig};
 use ark_ff::{BigInteger, Field, PrimeField, ToConstraintField};
 use ark_serialize::CanonicalSerialize;
+#[cfg(not(feature = "std"))]
+use ark_std::{string::String, vec::Vec};
 
 pub use ark_crypto_primitives_macros::*;
 

--- a/crypto-primitives/src/sponge/constraints/absorb.rs
+++ b/crypto-primitives/src/sponge/constraints/absorb.rs
@@ -13,6 +13,8 @@ use ark_r1cs_std::groups::curves::short_weierstrass::{
 use ark_r1cs_std::groups::curves::twisted_edwards::AffineVar as TEAffineVar;
 use ark_r1cs_std::uint8::UInt8;
 use ark_relations::r1cs::SynthesisError;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 /// An interface for objects that can be absorbed by a `CryptographicSpongeVar` whose constraint field
 /// is `CF`.

--- a/crypto-primitives/src/sponge/constraints/mod.rs
+++ b/crypto-primitives/src/sponge/constraints/mod.rs
@@ -9,6 +9,8 @@ use ark_r1cs_std::uint8::UInt8;
 use ark_r1cs_std::R1CSVar;
 use ark_relations::lc;
 use ark_relations::r1cs::{ConstraintSystemRef, LinearCombination, SynthesisError};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 mod absorb;
 pub use absorb::*;

--- a/crypto-primitives/src/sponge/mod.rs
+++ b/crypto-primitives/src/sponge/mod.rs
@@ -1,5 +1,6 @@
 use ark_ff::PrimeField;
-use ark_std::vec;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 /// Infrastructure for the constraints counterparts.
 #[cfg(feature = "r1cs")]

--- a/crypto-primitives/src/sponge/poseidon/constraints.rs
+++ b/crypto-primitives/src/sponge/poseidon/constraints.rs
@@ -7,6 +7,8 @@ use ark_ff::PrimeField;
 use ark_r1cs_std::fields::fp::FpVar;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 #[derive(Clone)]
 /// the gadget for Poseidon sponge

--- a/crypto-primitives/src/sponge/poseidon/grain_lfsr.rs
+++ b/crypto-primitives/src/sponge/poseidon/grain_lfsr.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
 use ark_ff::{BigInteger, PrimeField};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 pub struct PoseidonGrainLFSR {
     pub prime_num_bits: u64,

--- a/crypto-primitives/src/sponge/poseidon/mod.rs
+++ b/crypto-primitives/src/sponge/poseidon/mod.rs
@@ -5,6 +5,8 @@ use crate::sponge::{
 use ark_ff::{BigInteger, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::any::TypeId;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 /// constraints for Poseidon
 #[cfg(feature = "r1cs")]

--- a/crypto-primitives/src/sponge/poseidon/traits.rs
+++ b/crypto-primitives/src/sponge/poseidon/traits.rs
@@ -1,6 +1,8 @@
 use crate::sponge::poseidon::grain_lfsr::PoseidonGrainLFSR;
 use crate::sponge::poseidon::PoseidonConfig;
 use ark_ff::{fields::models::*, PrimeField};
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
 
 /// An entry in the default Poseidon parameters
 pub struct PoseidonDefaultConfigEntry {


### PR DESCRIPTION
Before this fix, if you run 
```
cargo build --no-default-features --features merkle_tree
```
you will get some errors. With this PR, we fix the imports for `Vec` in case of `no-std`.

Also, we changed CI to have different features so that we catch this kind of issue later.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
