### PR TITLE
Sort the imports and merge them

### DIFF
--- a/crypto-primitives/src/commitment/blake2s/constraints.rs
+++ b/crypto-primitives/src/commitment/blake2s/constraints.rs
@@ -1,13 +1,11 @@
-use ark_relations::r1cs::{Namespace, SynthesisError};
-
 use crate::{
     commitment::{blake2s, CommitmentGadget},
     prf::blake2s::constraints::{evaluate_blake2s, OutputVar},
 };
 use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::prelude::*;
-
-use core::borrow::Borrow;
+use ark_relations::r1cs::{Namespace, SynthesisError};
+use ark_std::borrow::Borrow;
 
 #[derive(Clone)]
 pub struct ParametersVar;

--- a/crypto-primitives/src/commitment/blake2s/mod.rs
+++ b/crypto-primitives/src/commitment/blake2s/mod.rs
@@ -1,5 +1,4 @@
-use super::CommitmentScheme;
-use crate::Error;
+use crate::{commitment::CommitmentScheme, Error};
 use ark_std::rand::Rng;
 use blake2::Blake2s256 as b2s;
 use digest::Digest;

--- a/crypto-primitives/src/commitment/constraints.rs
+++ b/crypto-primitives/src/commitment/constraints.rs
@@ -2,7 +2,7 @@ use crate::commitment::CommitmentScheme;
 use ark_ff::Field;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::SynthesisError;
-use core::fmt::Debug;
+use ark_std::fmt::Debug;
 
 pub trait CommitmentGadget<C: CommitmentScheme, ConstraintF: Field> {
     type OutputVar: EqGadget<ConstraintF>

--- a/crypto-primitives/src/commitment/injective_map/constraints.rs
+++ b/crypto-primitives/src/commitment/injective_map/constraints.rs
@@ -5,7 +5,6 @@ use crate::commitment::{
         Window,
     },
 };
-
 pub use crate::crh::injective_map::constraints::InjectiveMapGadget;
 use ark_ec::CurveGroup;
 use ark_ff::{Field, PrimeField};
@@ -14,7 +13,6 @@ use ark_r1cs_std::{
     uint8::UInt8,
 };
 use ark_relations::r1cs::SynthesisError;
-
 use ark_std::marker::PhantomData;
 
 type ConstraintF<C> = <<C as CurveGroup>::BaseField as Field>::BasePrimeField;

--- a/crypto-primitives/src/commitment/injective_map/mod.rs
+++ b/crypto-primitives/src/commitment/injective_map/mod.rs
@@ -1,10 +1,10 @@
-use crate::Error;
-use ark_std::marker::PhantomData;
-
-use super::{pedersen, CommitmentScheme};
 pub use crate::crh::injective_map::InjectiveMap;
+use crate::{
+    commitment::{pedersen, CommitmentScheme},
+    Error,
+};
 use ark_ec::CurveGroup;
-use ark_std::rand::Rng;
+use ark_std::{marker::PhantomData, rand::Rng};
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/commitment/mod.rs
+++ b/crypto-primitives/src/commitment/mod.rs
@@ -1,7 +1,7 @@
+use crate::Error;
 use ark_ff::UniformRand;
 use ark_serialize::CanonicalSerialize;
-use ark_std::rand::Rng;
-use ark_std::{fmt::Debug, hash::Hash};
+use ark_std::{fmt::Debug, hash::Hash, rand::Rng};
 
 pub mod blake2s;
 pub mod injective_map;
@@ -11,8 +11,6 @@ pub mod pedersen;
 pub mod constraints;
 #[cfg(feature = "r1cs")]
 pub use constraints::*;
-
-use crate::Error;
 
 pub trait CommitmentScheme {
     type Output: CanonicalSerialize + Clone + Default + Eq + Hash + Debug;

--- a/crypto-primitives/src/commitment/pedersen/constraints.rs
+++ b/crypto-primitives/src/commitment/pedersen/constraints.rs
@@ -7,11 +7,10 @@ use ark_ff::{
     fields::{Field, PrimeField},
     Zero,
 };
+use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_serialize::CanonicalSerialize;
-
-use ark_r1cs_std::prelude::*;
-use core::{borrow::Borrow, iter, marker::PhantomData};
+use ark_std::{borrow::Borrow, iter, marker::PhantomData};
 
 type ConstraintF<C> = <<C as CurveGroup>::BaseField as Field>::BasePrimeField;
 

--- a/crypto-primitives/src/commitment/pedersen/mod.rs
+++ b/crypto-primitives/src/commitment/pedersen/mod.rs
@@ -1,17 +1,15 @@
-use crate::{crh::CRHScheme, Error};
+use super::CommitmentScheme;
+pub use crate::crh::pedersen::Window;
+use crate::{
+    crh::{pedersen, CRHScheme},
+    Error,
+};
 use ark_ec::CurveGroup;
 use ark_ff::{BitIteratorLE, Field, PrimeField, ToConstraintField};
 use ark_serialize::CanonicalSerialize;
-use ark_std::marker::PhantomData;
-use ark_std::rand::Rng;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
-use ark_std::UniformRand;
-
-use super::CommitmentScheme;
-
-use crate::crh::pedersen;
-pub use crate::crh::pedersen::Window;
+use ark_std::{marker::PhantomData, rand::Rng, UniformRand};
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/constraints.rs
@@ -1,19 +1,18 @@
-use ark_ec::twisted_edwards::{Projective as TEProjective, TECurveConfig};
-use ark_ec::CurveConfig;
-use core::{borrow::Borrow, iter, marker::PhantomData};
-
 use crate::crh::{
-    bowe_hopwood::{Parameters, CHUNK_SIZE},
+    bowe_hopwood::{Parameters, TwoToOneCRH, CHUNK_SIZE, CRH},
     pedersen::{self, Window},
     CRHSchemeGadget, TwoToOneCRHSchemeGadget,
+};
+use ark_ec::{
+    twisted_edwards::{Projective as TEProjective, TECurveConfig},
+    CurveConfig,
 };
 use ark_ff::Field;
 use ark_r1cs_std::{groups::curves::twisted_edwards::AffineVar, prelude::*};
 use ark_relations::r1cs::{Namespace, SynthesisError};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
-
-use crate::crh::bowe_hopwood::{TwoToOneCRH, CRH};
+use ark_std::{borrow::Borrow, iter, marker::PhantomData};
 
 type ConstraintF<P> = <<P as CurveConfig>::BaseField as Field>::BasePrimeField;
 

--- a/crypto-primitives/src/crh/bowe_hopwood/mod.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/mod.rs
@@ -2,28 +2,28 @@
 //! specific Twisted Edwards (TE) curves. See [Section 5.4.17 of the Zcash protocol specification](https://raw.githubusercontent.com/zcash/zips/master/protocol/protocol.pdf#concretepedersenhash) for a formal description of this hash function, specialized for the Jubjub curve.
 //! The implementation in this repository is generic across choice of TE curves.
 
-use crate::Error;
-use ark_std::rand::Rng;
-use ark_std::{
-    fmt::{Debug, Formatter, Result as FmtResult},
-    marker::PhantomData,
+use crate::{
+    crh::{pedersen, CRHScheme, TwoToOneCRHScheme},
+    Error,
 };
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
-
-use super::pedersen;
-use crate::crh::{CRHScheme, TwoToOneCRHScheme};
 use ark_ec::{
     twisted_edwards::Projective as TEProjective, twisted_edwards::TECurveConfig, AdditiveGroup,
     CurveGroup,
 };
 use ark_ff::fields::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::borrow::Borrow;
-use ark_std::cfg_chunks;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
-use ark_std::UniformRand;
+use ark_std::{
+    borrow::Borrow,
+    cfg_chunks,
+    fmt::{Debug, Formatter, Result as FmtResult},
+    marker::PhantomData,
+    rand::Rng,
+    UniformRand,
+};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/crh/constraints.rs
+++ b/crypto-primitives/src/crh/constraints.rs
@@ -1,10 +1,8 @@
-use ark_ff::Field;
-use core::fmt::Debug;
-
 use crate::crh::{CRHScheme, TwoToOneCRHScheme};
-use ark_relations::r1cs::SynthesisError;
-
+use ark_ff::Field;
 use ark_r1cs_std::prelude::*;
+use ark_relations::r1cs::SynthesisError;
+use ark_std::fmt::Debug;
 
 pub trait CRHSchemeGadget<H: CRHScheme, ConstraintF: Field>: Sized {
     type InputVar: ?Sized;

--- a/crypto-primitives/src/crh/injective_map/constraints.rs
+++ b/crypto-primitives/src/crh/injective_map/constraints.rs
@@ -1,13 +1,11 @@
 use crate::crh::{
     constraints,
-    injective_map::{InjectiveMap, PedersenCRHCompressor, TECompressor},
+    injective_map::{
+        InjectiveMap, PedersenCRHCompressor, PedersenTwoToOneCRHCompressor, TECompressor,
+    },
     pedersen::{constraints as ped_constraints, Window},
-    TwoToOneCRHSchemeGadget,
+    CRHSchemeGadget, TwoToOneCRHSchemeGadget,
 };
-use ark_std::{fmt::Debug, marker::PhantomData};
-
-use crate::crh::injective_map::PedersenTwoToOneCRHCompressor;
-use crate::crh::CRHSchemeGadget;
 use ark_ec::{
     twisted_edwards::{Projective as TEProjective, TECurveConfig},
     CurveConfig, CurveGroup,
@@ -17,6 +15,7 @@ use ark_r1cs_std::{
     fields::fp::FpVar, groups::curves::twisted_edwards::AffineVar as TEVar, prelude::*,
 };
 use ark_relations::r1cs::SynthesisError;
+use ark_std::{fmt::Debug, marker::PhantomData};
 
 type ConstraintF<C> = <<C as CurveGroup>::BaseField as Field>::BasePrimeField;
 

--- a/crypto-primitives/src/crh/injective_map/mod.rs
+++ b/crypto-primitives/src/crh/injective_map/mod.rs
@@ -1,16 +1,15 @@
-use crate::Error;
-use ark_std::rand::Rng;
-#[cfg(not(feature = "std"))]
-use ark_std::vec::Vec;
-use ark_std::{fmt::Debug, hash::Hash, marker::PhantomData};
-
-use super::{pedersen, CRHScheme, TwoToOneCRHScheme};
+use crate::{
+    crh::{pedersen, CRHScheme, TwoToOneCRHScheme},
+    Error,
+};
 use ark_ec::{
     twisted_edwards::{Affine as TEAffine, Projective as TEProjective, TECurveConfig},
     CurveConfig, CurveGroup,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::borrow::Borrow;
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
+use ark_std::{borrow::Borrow, fmt::Debug, hash::Hash, marker::PhantomData, rand::Rng};
 #[cfg(feature = "r1cs")]
 pub mod constraints;
 

--- a/crypto-primitives/src/crh/mod.rs
+++ b/crypto-primitives/src/crh/mod.rs
@@ -1,20 +1,14 @@
 #![allow(clippy::upper_case_acronyms)]
-
-use ark_std::hash::Hash;
-use ark_std::rand::Rng;
+use crate::Error;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::{borrow::Borrow, hash::Hash, rand::Rng};
 pub mod bowe_hopwood;
+#[cfg(feature = "r1cs")]
+pub mod constraints;
 pub mod injective_map;
 pub mod pedersen;
 pub mod poseidon;
 pub mod sha256;
-
-use crate::Error;
-
-#[cfg(feature = "r1cs")]
-pub mod constraints;
-
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::borrow::Borrow;
 #[cfg(feature = "r1cs")]
 pub use constraints::*;
 

--- a/crypto-primitives/src/crh/mod.rs
+++ b/crypto-primitives/src/crh/mod.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::upper_case_acronyms)]
 use crate::Error;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::{borrow::Borrow, hash::Hash, rand::Rng};
+use ark_std::{borrow::Borrow, fmt::Debug, hash::Hash, rand::Rng};
+
 pub mod bowe_hopwood;
 #[cfg(feature = "r1cs")]
 pub mod constraints;
@@ -16,13 +17,7 @@ pub use constraints::*;
 /// variable length CRH may also implement this trait in future.
 pub trait CRHScheme {
     type Input: ?Sized + Send;
-    type Output: Clone
-        + Eq
-        + core::fmt::Debug
-        + Hash
-        + Default
-        + CanonicalSerialize
-        + CanonicalDeserialize;
+    type Output: Clone + Eq + Debug + Hash + Default + CanonicalSerialize + CanonicalDeserialize;
     type Parameters: Clone + CanonicalSerialize + CanonicalDeserialize + Sync;
 
     fn setup<R: Rng>(r: &mut R) -> Result<Self::Parameters, Error>;
@@ -37,13 +32,7 @@ pub trait TwoToOneCRHScheme {
     /// Raw Input type of TwoToOneCRH
     type Input: ?Sized;
     /// Raw Output type of TwoToOneCRH
-    type Output: Clone
-        + Eq
-        + core::fmt::Debug
-        + Hash
-        + Default
-        + CanonicalSerialize
-        + CanonicalDeserialize;
+    type Output: Clone + Eq + Debug + Hash + Default + CanonicalSerialize + CanonicalDeserialize;
     type Parameters: Clone + CanonicalSerialize + CanonicalDeserialize + Sync;
 
     fn setup<R: Rng>(r: &mut R) -> Result<Self::Parameters, Error>;

--- a/crypto-primitives/src/crh/pedersen/constraints.rs
+++ b/crypto-primitives/src/crh/pedersen/constraints.rs
@@ -1,6 +1,6 @@
 use crate::crh::{
-    pedersen::{Parameters, Window},
-    CRHSchemeGadget as CRHGadgetTrait,
+    pedersen::{Parameters, TwoToOneCRH, Window, CRH},
+    CRHSchemeGadget as CRHGadgetTrait, CRHSchemeGadget, TwoToOneCRHSchemeGadget,
 };
 use ark_ec::CurveGroup;
 use ark_ff::Field;
@@ -8,10 +8,7 @@ use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::{Namespace, SynthesisError};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
-
-use crate::crh::pedersen::{TwoToOneCRH, CRH};
-use crate::crh::{CRHSchemeGadget, TwoToOneCRHSchemeGadget};
-use core::{borrow::Borrow, iter, marker::PhantomData};
+use ark_std::{borrow::Borrow, iter, marker::PhantomData};
 
 #[derive(Derivative)]
 #[derivative(Clone(bound = "C: CurveGroup, GG: CurveVar<C, ConstraintF<C>>"))]

--- a/crypto-primitives/src/crh/pedersen/mod.rs
+++ b/crypto-primitives/src/crh/pedersen/mod.rs
@@ -1,20 +1,21 @@
-use crate::Error;
-use ark_std::rand::Rng;
-use ark_std::{
-    fmt::{Debug, Formatter, Result as FmtResult},
-    marker::PhantomData,
+use crate::{
+    crh::{CRHScheme, TwoToOneCRHScheme},
+    Error,
 };
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
-
-use crate::crh::{CRHScheme, TwoToOneCRHScheme};
 use ark_ec::CurveGroup;
 use ark_ff::{Field, ToConstraintField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::borrow::Borrow;
-use ark_std::cfg_chunks;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
+use ark_std::{
+    borrow::Borrow,
+    cfg_chunks,
+    fmt::{Debug, Formatter, Result as FmtResult},
+    marker::PhantomData,
+    rand::Rng,
+};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/crh/poseidon/constraints.rs
+++ b/crypto-primitives/src/crh/poseidon/constraints.rs
@@ -1,22 +1,25 @@
-use crate::crh::poseidon::{TwoToOneCRH, CRH};
-use crate::crh::CRHScheme;
-use crate::crh::{
-    CRHSchemeGadget as CRHGadgetTrait, TwoToOneCRHSchemeGadget as TwoToOneCRHGadgetTrait,
+use crate::{
+    crh::{
+        poseidon::{TwoToOneCRH, CRH},
+        CRHScheme, CRHSchemeGadget as CRHGadgetTrait,
+        TwoToOneCRHSchemeGadget as TwoToOneCRHGadgetTrait,
+    },
+    sponge::{
+        constraints::CryptographicSpongeVar,
+        poseidon::{constraints::PoseidonSpongeVar, PoseidonConfig},
+        Absorb,
+    },
 };
-use crate::sponge::constraints::CryptographicSpongeVar;
-use crate::sponge::poseidon::constraints::PoseidonSpongeVar;
-use crate::sponge::poseidon::PoseidonConfig;
-
-use crate::sponge::Absorb;
 use ark_ff::PrimeField;
-use ark_r1cs_std::alloc::{AllocVar, AllocationMode};
-use ark_r1cs_std::fields::fp::FpVar;
-use ark_r1cs_std::R1CSVar;
+use ark_r1cs_std::{
+    alloc::{AllocVar, AllocationMode},
+    fields::fp::FpVar,
+    R1CSVar,
+};
 use ark_relations::r1cs::{Namespace, SynthesisError};
-use ark_std::borrow::Borrow;
-use ark_std::marker::PhantomData;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
+use ark_std::{borrow::Borrow, marker::PhantomData};
 
 #[derive(Clone)]
 pub struct CRHParametersVar<F: PrimeField + Absorb> {

--- a/crypto-primitives/src/crh/poseidon/mod.rs
+++ b/crypto-primitives/src/crh/poseidon/mod.rs
@@ -1,11 +1,13 @@
-use crate::crh::TwoToOneCRHScheme;
-use crate::sponge::poseidon::{PoseidonConfig, PoseidonSponge};
-use crate::sponge::{Absorb, CryptographicSponge};
-use crate::{crh::CRHScheme, Error};
+use crate::{
+    crh::{CRHScheme, TwoToOneCRHScheme},
+    sponge::{
+        poseidon::{PoseidonConfig, PoseidonSponge},
+        Absorb, CryptographicSponge,
+    },
+    Error,
+};
 use ark_ff::PrimeField;
-use ark_std::borrow::Borrow;
-use ark_std::marker::PhantomData;
-use ark_std::rand::Rng;
+use ark_std::{borrow::Borrow, marker::PhantomData, rand::Rng};
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/crh/sha256/constraints.rs
+++ b/crypto-primitives/src/crh/sha256/constraints.rs
@@ -4,9 +4,6 @@
 // Thank you!
 
 use crate::crh::{sha256::Sha256, CRHSchemeGadget, TwoToOneCRHSchemeGadget};
-
-use core::{borrow::Borrow, iter, marker::PhantomData};
-
 use ark_ff::PrimeField;
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
@@ -21,6 +18,7 @@ use ark_r1cs_std::{
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
+use ark_std::{borrow::Borrow, iter, marker::PhantomData};
 
 const STATE_LEN: usize = 8;
 

--- a/crypto-primitives/src/crh/sha256/mod.rs
+++ b/crypto-primitives/src/crh/sha256/mod.rs
@@ -2,9 +2,10 @@ use crate::{
     crh::{CRHScheme, TwoToOneCRHScheme},
     Error,
 };
-use ark_std::rand::Rng;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
+use ark_std::{borrow::Borrow, rand::Rng};
+use sha2::digest::Digest;
 
 // Re-export the RustCrypto Sha256 type and its associated traits
 pub use sha2::{digest, Sha256};
@@ -13,10 +14,6 @@ pub use sha2::{digest, Sha256};
 pub mod constraints;
 
 // Implement the CRH traits for SHA-256
-
-use core::borrow::Borrow;
-use sha2::digest::Digest;
-
 impl CRHScheme for Sha256 {
     type Input = [u8];
     // This is always 32 bytes. It has to be a Vec to impl CanonicalSerialize

--- a/crypto-primitives/src/crh/sha256/mod.rs
+++ b/crypto-primitives/src/crh/sha256/mod.rs
@@ -1,6 +1,7 @@
-use crate::crh::{CRHScheme, TwoToOneCRHScheme};
-use crate::Error;
-
+use crate::{
+    crh::{CRHScheme, TwoToOneCRHScheme},
+    Error,
+};
 use ark_std::rand::Rng;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;

--- a/crypto-primitives/src/encryption/constraints.rs
+++ b/crypto-primitives/src/encryption/constraints.rs
@@ -1,10 +1,8 @@
 use crate::encryption::AsymmetricEncryptionScheme;
-
+use ark_ff::fields::Field;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::SynthesisError;
-use core::fmt::Debug;
-
-use ark_ff::fields::Field;
+use ark_std::fmt::Debug;
 
 pub trait AsymmetricEncryptionGadget<C: AsymmetricEncryptionScheme, ConstraintF: Field> {
     type OutputVar: AllocVar<C::Ciphertext, ConstraintF>

--- a/crypto-primitives/src/encryption/elgamal/constraints.rs
+++ b/crypto-primitives/src/encryption/elgamal/constraints.rs
@@ -1,15 +1,14 @@
-use ark_r1cs_std::prelude::*;
-use ark_relations::r1cs::{Namespace, SynthesisError};
-
-use crate::encryption::elgamal::{
-    Ciphertext, ElGamal, Parameters, Plaintext, PublicKey, Randomness,
+use crate::encryption::{
+    elgamal::{Ciphertext, ElGamal, Parameters, Plaintext, PublicKey, Randomness},
+    AsymmetricEncryptionGadget,
 };
-use crate::encryption::AsymmetricEncryptionGadget;
 use ark_ec::CurveGroup;
 use ark_ff::{
     fields::{Field, PrimeField},
     Zero,
 };
+use ark_r1cs_std::prelude::*;
+use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_serialize::CanonicalSerialize;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;

--- a/crypto-primitives/src/encryption/elgamal/mod.rs
+++ b/crypto-primitives/src/encryption/elgamal/mod.rs
@@ -1,13 +1,10 @@
-#[cfg(feature = "r1cs")]
-pub mod constraints;
-
-use crate::encryption::AsymmetricEncryptionScheme;
-use crate::Error;
+use crate::{encryption::AsymmetricEncryptionScheme, Error};
 use ark_ec::{AdditiveGroup, CurveGroup};
 use ark_ff::{fields::PrimeField, UniformRand};
-use ark_std::marker::PhantomData;
-use ark_std::ops::Mul;
-use ark_std::rand::Rng;
+use ark_std::{marker::PhantomData, ops::Mul, rand::Rng};
+
+#[cfg(feature = "r1cs")]
+pub mod constraints;
 
 pub struct ElGamal<C: CurveGroup> {
     _group: PhantomData<C>,

--- a/crypto-primitives/src/encryption/mod.rs
+++ b/crypto-primitives/src/encryption/mod.rs
@@ -1,12 +1,11 @@
-#[cfg(feature = "r1cs")]
-pub mod constraints;
-#[cfg(feature = "r1cs")]
-pub use constraints::*;
-
-pub mod elgamal;
-
 use crate::Error;
 use ark_std::rand::Rng;
+
+#[cfg(feature = "r1cs")]
+pub mod constraints;
+pub mod elgamal;
+#[cfg(feature = "r1cs")]
+pub use constraints::*;
 
 pub trait AsymmetricEncryptionScheme {
     type Parameters;

--- a/crypto-primitives/src/lib.rs
+++ b/crypto-primitives/src/lib.rs
@@ -51,8 +51,8 @@ pub enum Error {
     SerializationError(ark_serialize::SerializationError),
 }
 
-impl core::fmt::Display for Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl ark_std::fmt::Display for Error {
+    fn fmt(&self, f: &mut ark_std::fmt::Formatter<'_>) -> ark_std::fmt::Result {
         match self {
             Self::IncorrectInputLength(len) => write!(f, "incorrect input length: {len}"),
             Self::NotPrimeOrder => write!(f, "element is not prime order"),

--- a/crypto-primitives/src/merkle_tree/constraints.rs
+++ b/crypto-primitives/src/merkle_tree/constraints.rs
@@ -5,9 +5,9 @@ use crate::{
 use ark_ff::PrimeField;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::{Namespace, SynthesisError};
-use ark_std::{borrow::Borrow, fmt::Debug};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
+use ark_std::{borrow::Borrow, fmt::Debug};
 
 pub trait DigestVarConverter<From, To: ?Sized> {
     type TargetType: Borrow<To>;

--- a/crypto-primitives/src/merkle_tree/constraints.rs
+++ b/crypto-primitives/src/merkle_tree/constraints.rs
@@ -1,11 +1,11 @@
-use crate::crh::TwoToOneCRHSchemeGadget;
-use crate::merkle_tree::{Config, IdentityDigestConverter};
-use crate::{crh::CRHSchemeGadget, merkle_tree::Path};
+use crate::{
+    crh::{CRHSchemeGadget, TwoToOneCRHSchemeGadget},
+    merkle_tree::{Config, IdentityDigestConverter, Path},
+};
 use ark_ff::PrimeField;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::{Namespace, SynthesisError};
-use ark_std::borrow::Borrow;
-use ark_std::fmt::Debug;
+use ark_std::{borrow::Borrow, fmt::Debug};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
 

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
-use ark_std::{borrow::Borrow, collections::BTreeSet, hash::Hash};
+use ark_std::{borrow::Borrow, collections::BTreeSet, fmt::Debug, hash::Hash};
 use hashbrown::HashMap;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -62,7 +62,7 @@ pub trait Config {
                               // leaf layer
     type LeafDigest: Clone
         + Eq
-        + core::fmt::Debug
+        + Debug
         + Hash
         + Default
         + CanonicalSerialize
@@ -78,7 +78,7 @@ pub trait Config {
     // inner layer
     type InnerDigest: Clone
         + Eq
-        + core::fmt::Debug
+        + Debug
         + Hash
         + Default
         + CanonicalSerialize

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -1,25 +1,23 @@
 #![allow(clippy::needless_range_loop)]
 
 /// Defines a trait to chain two types of CRHs.
-use crate::crh::TwoToOneCRHScheme;
-use crate::sponge::Absorb;
-use crate::{crh::CRHScheme, Error};
+use crate::{
+    crh::{CRHScheme, TwoToOneCRHScheme},
+    sponge::Absorb,
+    Error,
+};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::borrow::Borrow;
-use ark_std::collections::BTreeSet;
-use ark_std::hash::Hash;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
+use ark_std::{borrow::Borrow, collections::BTreeSet, hash::Hash};
 use hashbrown::HashMap;
+#[cfg(feature = "parallel")]
+use rayon::prelude::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
+};
 
 #[cfg(test)]
 mod tests;
-
-#[cfg(feature = "r1cs")]
-pub mod constraints;
-
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
 
 /// Convert the hash digest in different layers by converting previous layer's output to
 /// `TargetType`, which is a `Borrow` to next layer's input.

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -12,9 +12,10 @@ use ark_std::vec::Vec;
 use ark_std::{borrow::Borrow, collections::BTreeSet, hash::Hash};
 use hashbrown::HashMap;
 #[cfg(feature = "parallel")]
-use rayon::prelude::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator,
-};
+use rayon::prelude::*;
+
+#[cfg(feature = "r1cs")]
+pub mod constraints;
 
 #[cfg(test)]
 mod tests;

--- a/crypto-primitives/src/merkle_tree/tests/constraints.rs
+++ b/crypto-primitives/src/merkle_tree/tests/constraints.rs
@@ -1,9 +1,11 @@
 mod byte_mt_tests {
-    use crate::crh::{pedersen, TwoToOneCRHScheme, TwoToOneCRHSchemeGadget};
-
-    use crate::crh::{CRHScheme, CRHSchemeGadget};
-    use crate::merkle_tree::constraints::{BytesVarDigestConverter, ConfigGadget};
-    use crate::merkle_tree::{constraints::PathVar, ByteDigestConverter, Config, MerkleTree};
+    use crate::crh::{
+        pedersen, CRHScheme, CRHSchemeGadget, TwoToOneCRHScheme, TwoToOneCRHSchemeGadget,
+    };
+    use crate::merkle_tree::{
+        constraints::{BytesVarDigestConverter, ConfigGadget, PathVar},
+        ByteDigestConverter, Config, MerkleTree,
+    };
     use ark_ed_on_bls12_381::{constraints::EdwardsVar, EdwardsProjective as JubJub, Fq};
     use ark_r1cs_std::prelude::*;
     use ark_relations::r1cs::ConstraintSystem;
@@ -234,13 +236,14 @@ mod byte_mt_tests {
 
 mod field_mt_tests {
     use crate::crh::{poseidon, CRHSchemeGadget, TwoToOneCRHSchemeGadget};
-    use crate::merkle_tree::constraints::ConfigGadget;
-    use crate::merkle_tree::tests::test_utils::poseidon_parameters;
-    use crate::merkle_tree::{constraints::PathVar, Config, IdentityDigestConverter, MerkleTree};
-    use ark_r1cs_std::fields::fp::FpVar;
-    use ark_r1cs_std::uint32::UInt32;
-    use ark_r1cs_std::R1CSVar;
-    use ark_r1cs_std::{alloc::AllocVar, convert::ToBitsGadget};
+    use crate::merkle_tree::{
+        constraints::{ConfigGadget, PathVar},
+        tests::test_utils::poseidon_parameters,
+        Config, IdentityDigestConverter, MerkleTree,
+    };
+    use ark_r1cs_std::{
+        alloc::AllocVar, convert::ToBitsGadget, fields::fp::FpVar, uint32::UInt32, R1CSVar,
+    };
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, One, UniformRand};
 

--- a/crypto-primitives/src/merkle_tree/tests/mod.rs
+++ b/crypto-primitives/src/merkle_tree/tests/mod.rs
@@ -7,8 +7,7 @@ mod bytes_mt_tests {
     use crate::{crh::*, merkle_tree::*};
     use ark_ed_on_bls12_381::EdwardsProjective as JubJub;
     use ark_ff::BigInteger256;
-    use ark_std::{test_rng, UniformRand};
-    use std::iter::zip;
+    use ark_std::{iter::zip, test_rng, UniformRand};
 
     #[derive(Clone)]
     pub(super) struct Window4x256;
@@ -184,9 +183,12 @@ mod bytes_mt_tests {
 }
 
 mod field_mt_tests {
-    use crate::crh::poseidon;
-    use crate::merkle_tree::tests::test_utils::poseidon_parameters;
-    use crate::merkle_tree::{Config, IdentityDigestConverter, MerkleTree};
+    use crate::{
+        crh::poseidon,
+        merkle_tree::{
+            tests::test_utils::poseidon_parameters, Config, IdentityDigestConverter, MerkleTree,
+        },
+    };
     use ark_std::{test_rng, One, UniformRand};
 
     type F = ark_ed_on_bls12_381::Fr;

--- a/crypto-primitives/src/merkle_tree/tests/test_utils.rs
+++ b/crypto-primitives/src/merkle_tree/tests/test_utils.rs
@@ -1,6 +1,5 @@
 use crate::sponge::poseidon::PoseidonConfig;
-use ark_std::str::FromStr;
-use ark_std::{One, Zero};
+use ark_std::{str::FromStr, One, Zero};
 
 type F = ark_ed_on_bls12_381::Fr;
 

--- a/crypto-primitives/src/prf/blake2s/constraints.rs
+++ b/crypto-primitives/src/prf/blake2s/constraints.rs
@@ -1,12 +1,10 @@
-use ark_ff::PrimeField;
-use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
-
 use crate::prf::PRFGadget;
+use ark_ff::PrimeField;
 use ark_r1cs_std::prelude::*;
+use ark_relations::r1cs::{ConstraintSystemRef, Namespace, SynthesisError};
+use ark_std::borrow::Borrow;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
-
-use core::borrow::Borrow;
 
 // 2.1.  Parameters
 // The following table summarizes various parameters and their ranges:

--- a/crypto-primitives/src/prf/blake2s/mod.rs
+++ b/crypto-primitives/src/prf/blake2s/mod.rs
@@ -1,10 +1,8 @@
+use crate::{prf::PRF, Error};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
 use blake2::{Blake2s256 as B2s, Blake2sMac};
 use digest::Digest;
-
-use super::PRF;
-use crate::Error;
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/prf/constraints.rs
+++ b/crypto-primitives/src/prf/constraints.rs
@@ -1,10 +1,8 @@
-use ark_ff::Field;
-use core::fmt::Debug;
-
 use crate::prf::PRF;
-use ark_relations::r1cs::{Namespace, SynthesisError};
-
+use ark_ff::Field;
 use ark_r1cs_std::prelude::*;
+use ark_relations::r1cs::{Namespace, SynthesisError};
+use ark_std::fmt::Debug;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
 

--- a/crypto-primitives/src/prf/mod.rs
+++ b/crypto-primitives/src/prf/mod.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::upper_case_acronyms)]
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use core::{fmt::Debug, hash::Hash};
-
 use crate::Error;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::{fmt::Debug, hash::Hash};
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/signature/constraints.rs
+++ b/crypto-primitives/src/signature/constraints.rs
@@ -1,8 +1,7 @@
+use crate::signature::SignatureScheme;
 use ark_ff::Field;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::SynthesisError;
-
-use crate::signature::SignatureScheme;
 
 pub trait SigVerifyGadget<S: SignatureScheme, ConstraintF: Field> {
     type ParametersVar: AllocVar<S::Parameters, ConstraintF> + Clone;

--- a/crypto-primitives/src/signature/mod.rs
+++ b/crypto-primitives/src/signature/mod.rs
@@ -1,7 +1,6 @@
 use crate::Error;
 use ark_serialize::CanonicalSerialize;
-use ark_std::hash::Hash;
-use ark_std::rand::Rng;
+use ark_std::{hash::Hash, rand::Rng};
 
 #[cfg(feature = "r1cs")]
 pub mod constraints;

--- a/crypto-primitives/src/signature/schnorr/constraints.rs
+++ b/crypto-primitives/src/signature/schnorr/constraints.rs
@@ -1,15 +1,14 @@
+use crate::signature::{
+    schnorr::{Parameters, PublicKey, Schnorr},
+    SigRandomizePkGadget,
+};
 use ark_ec::CurveGroup;
 use ark_ff::Field;
 use ark_r1cs_std::prelude::*;
 use ark_relations::r1cs::{Namespace, SynthesisError};
-
-use crate::signature::SigRandomizePkGadget;
-
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
 use ark_std::{borrow::Borrow, marker::PhantomData};
-
-use crate::signature::schnorr::{Parameters, PublicKey, Schnorr};
 use digest::Digest;
 
 type ConstraintF<C> = <<C as CurveGroup>::BaseField as Field>::BasePrimeField;

--- a/crypto-primitives/src/signature/schnorr/mod.rs
+++ b/crypto-primitives/src/signature/schnorr/mod.rs
@@ -5,11 +5,9 @@ use ark_ff::{
     AdditiveGroup, One, ToConstraintField, UniformRand, Zero,
 };
 use ark_serialize::CanonicalSerialize;
-use ark_std::ops::Mul;
-use ark_std::rand::Rng;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
-use ark_std::{hash::Hash, marker::PhantomData};
+use ark_std::{hash::Hash, marker::PhantomData, ops::Mul, rand::Rng};
 use digest::Digest;
 
 #[cfg(feature = "r1cs")]

--- a/crypto-primitives/src/snark/constraints.rs
+++ b/crypto-primitives/src/snark/constraints.rs
@@ -1,17 +1,19 @@
 use ark_ff::{BigInteger, PrimeField};
-use ark_r1cs_std::fields::{
-    emulated_fp::{
-        params::{get_params, OptimizationType},
-        AllocatedEmulatedFpVar, EmulatedFpVar,
+use ark_r1cs_std::{
+    fields::{
+        emulated_fp::{
+            params::{get_params, OptimizationType},
+            AllocatedEmulatedFpVar, EmulatedFpVar,
+        },
+        fp::{AllocatedFp, FpVar},
     },
-    fp::{AllocatedFp, FpVar},
+    prelude::*,
 };
-use ark_r1cs_std::prelude::*;
-use ark_relations::r1cs::OptimizationGoal;
 use ark_relations::{
     lc, ns,
     r1cs::{
-        ConstraintSynthesizer, ConstraintSystemRef, LinearCombination, Namespace, SynthesisError,
+        ConstraintSynthesizer, ConstraintSystemRef, LinearCombination, Namespace, OptimizationGoal,
+        SynthesisError,
     },
 };
 use ark_snark::{CircuitSpecificSetupSNARK, UniversalSetupSNARK, SNARK};

--- a/crypto-primitives/src/sponge/absorb.rs
+++ b/crypto-primitives/src/sponge/absorb.rs
@@ -1,16 +1,15 @@
-use ark_ec::short_weierstrass::Affine as SWAffine;
-use ark_ec::twisted_edwards::Affine as TEAffine;
+pub use ark_crypto_primitives_macros::*;
 use ark_ec::{
-    short_weierstrass::SWCurveConfig as SWModelParameters,
-    twisted_edwards::TECurveConfig as TEModelParameters,
+    short_weierstrass::{Affine as SWAffine, SWCurveConfig as SWModelParameters},
+    twisted_edwards::{Affine as TEAffine, TECurveConfig as TEModelParameters},
 };
-use ark_ff::models::{Fp, FpConfig};
-use ark_ff::{BigInteger, Field, PrimeField, ToConstraintField};
+use ark_ff::{
+    models::{Fp, FpConfig},
+    BigInteger, Field, PrimeField, ToConstraintField,
+};
 use ark_serialize::CanonicalSerialize;
 #[cfg(not(feature = "std"))]
 use ark_std::{string::String, vec::Vec};
-
-pub use ark_crypto_primitives_macros::*;
 
 /// An interface for objects that can be absorbed by a `CryptographicSponge`.
 pub trait Absorb {

--- a/crypto-primitives/src/sponge/constraints/absorb.rs
+++ b/crypto-primitives/src/sponge/constraints/absorb.rs
@@ -3,15 +3,16 @@ use ark_ec::{
     twisted_edwards::TECurveConfig as TEModelParameters, CurveConfig as ModelParameters,
 };
 use ark_ff::{Field, PrimeField};
-use ark_r1cs_std::boolean::Boolean;
-use ark_r1cs_std::convert::{ToBytesGadget, ToConstraintFieldGadget};
-use ark_r1cs_std::fields::fp::FpVar;
-use ark_r1cs_std::fields::{FieldOpsBounds, FieldVar};
-use ark_r1cs_std::groups::curves::short_weierstrass::{
-    AffineVar as SWAffineVar, ProjectiveVar as SWProjectiveVar,
+use ark_r1cs_std::{
+    boolean::Boolean,
+    convert::{ToBytesGadget, ToConstraintFieldGadget},
+    fields::{fp::FpVar, FieldOpsBounds, FieldVar},
+    groups::curves::{
+        short_weierstrass::{AffineVar as SWAffineVar, ProjectiveVar as SWProjectiveVar},
+        twisted_edwards::AffineVar as TEAffineVar,
+    },
+    uint8::UInt8,
 };
-use ark_r1cs_std::groups::curves::twisted_edwards::AffineVar as TEAffineVar;
-use ark_r1cs_std::uint8::UInt8;
 use ark_relations::r1cs::SynthesisError;
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;

--- a/crypto-primitives/src/sponge/constraints/mod.rs
+++ b/crypto-primitives/src/sponge/constraints/mod.rs
@@ -1,14 +1,22 @@
 use crate::sponge::{Absorb, CryptographicSponge, FieldElementSize};
 use ark_ff::PrimeField;
-use ark_r1cs_std::alloc::AllocVar;
-use ark_r1cs_std::boolean::Boolean;
-use ark_r1cs_std::fields::emulated_fp::params::{get_params, OptimizationType};
-use ark_r1cs_std::fields::emulated_fp::{AllocatedEmulatedFpVar, EmulatedFpVar};
-use ark_r1cs_std::fields::fp::{AllocatedFp, FpVar};
-use ark_r1cs_std::uint8::UInt8;
-use ark_r1cs_std::R1CSVar;
-use ark_relations::lc;
-use ark_relations::r1cs::{ConstraintSystemRef, LinearCombination, SynthesisError};
+use ark_r1cs_std::{
+    alloc::AllocVar,
+    boolean::Boolean,
+    fields::{
+        emulated_fp::{
+            params::{get_params, OptimizationType},
+            AllocatedEmulatedFpVar, EmulatedFpVar,
+        },
+        fp::{AllocatedFp, FpVar},
+    },
+    uint8::UInt8,
+    R1CSVar,
+};
+use ark_relations::{
+    lc,
+    r1cs::{ConstraintSystemRef, LinearCombination, SynthesisError},
+};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
 

--- a/crypto-primitives/src/sponge/poseidon/constraints.rs
+++ b/crypto-primitives/src/sponge/poseidon/constraints.rs
@@ -1,11 +1,10 @@
-use crate::sponge::constraints::AbsorbGadget;
-use crate::sponge::constraints::{CryptographicSpongeVar, SpongeWithGadget};
-use crate::sponge::poseidon::{PoseidonConfig, PoseidonSponge};
-use crate::sponge::DuplexSpongeMode;
-
+use crate::sponge::{
+    constraints::{AbsorbGadget, CryptographicSpongeVar, SpongeWithGadget},
+    poseidon::{PoseidonConfig, PoseidonSponge},
+    DuplexSpongeMode,
+};
 use ark_ff::PrimeField;
-use ark_r1cs_std::fields::fp::FpVar;
-use ark_r1cs_std::prelude::*;
+use ark_r1cs_std::{fields::fp::FpVar, prelude::*};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;

--- a/crypto-primitives/src/sponge/poseidon/tests.rs
+++ b/crypto-primitives/src/sponge/poseidon/tests.rs
@@ -1,7 +1,11 @@
-use crate::sponge::poseidon::{PoseidonConfig, PoseidonSponge};
-use crate::sponge::test::Fr;
-use crate::sponge::{Absorb, AbsorbWithLength, CryptographicSponge, FieldBasedCryptographicSponge};
-use crate::{absorb, collect_sponge_bytes, collect_sponge_field_elements};
+use crate::{
+    absorb, collect_sponge_bytes, collect_sponge_field_elements,
+    sponge::{
+        poseidon::{PoseidonConfig, PoseidonSponge},
+        test::Fr,
+        Absorb, AbsorbWithLength, CryptographicSponge, FieldBasedCryptographicSponge,
+    },
+};
 use ark_ff::{One, PrimeField, UniformRand};
 use ark_std::test_rng;
 

--- a/crypto-primitives/src/sponge/poseidon/traits.rs
+++ b/crypto-primitives/src/sponge/poseidon/traits.rs
@@ -1,5 +1,4 @@
-use crate::sponge::poseidon::grain_lfsr::PoseidonGrainLFSR;
-use crate::sponge::poseidon::PoseidonConfig;
+use crate::sponge::poseidon::{grain_lfsr::PoseidonGrainLFSR, PoseidonConfig};
 use ark_ff::{fields::models::*, PrimeField};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;


### PR DESCRIPTION
This PR sorts the imports by `cargo fmt` and merges them.
Also, I removed some places that were using `core` and replaced them with `ark_std`. Please check if it is correct.

By the way, there is `pub(crate) use ark_std::vec::Vec` in `lib.rs`. I don't understand why we still have to import it when it is no-std? @mmagician 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against the correct branch (main)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
