### PR TITLE
Make dependency on ark-relations optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Improvements
 
+- [\#146](https://github.com/arkworks-rs/crypto-primitives/pull/146) Make dependency on
+`ark-relations` optional, do not depend on it for the `std` feature.
+
 ### Bugfixes
 
 ## v0.4.0

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -20,7 +20,7 @@ ark-crypto-primitives-macros = { version = "^0.4.0", path = "../macros" }
 ark-ff = { version = "^0.4.0", default-features = false }
 ark-ec = { version = "^0.4.0", default-features = false }
 ark-std = { version = "^0.4.0", default-features = false }
-ark-relations = { version = "^0.4.0", default-features = false }
+ark-relations = { version = "^0.4.0", optional = true, default-features = false }
 ark-serialize = { version = "^0.4.0", default-features = false, features = [ "derive" ] }
 
 blake2 = { version = "0.10", default-features = false }
@@ -37,10 +37,10 @@ hashbrown = { version = "0.14", default-features = false, features = ["inline-mo
 
 [features]
 default = ["std"]
-std = [ "ark-ff/std", "ark-ec/std", "ark-std/std", "ark-relations/std" ]
+std = [ "ark-ff/std", "ark-ec/std", "ark-std/std" ]
 print-trace = [ "ark-std/print-trace" ]
 parallel = [ "std", "rayon", "ark-ec/parallel", "ark-std/parallel", "ark-ff/parallel" ]
-r1cs = [ "ark-r1cs-std", "tracing" ]
+r1cs = [ "ark-r1cs-std", "ark-relations", "tracing"]
 crh = [ "sponge" ]
 sponge = []
 commitment = ["crh"]


### PR DESCRIPTION
## Description

The std feature of ark-relations pulls in some hefty dependencies, including tracing-subscriber.
Remove the dependency on ark-relations/std because it is not needed.
Make ark-relations (without fetures) a conditional dependency, only enabled for r1cs where it is required.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
