### PR TITLE
Undo changes in `0960300`

### DIFF
--- a/crypto-primitives/src/merkle_tree/constraints.rs
+++ b/crypto-primitives/src/merkle_tree/constraints.rs
@@ -1,6 +1,6 @@
 use crate::{
     crh::{CRHSchemeGadget, TwoToOneCRHSchemeGadget},
-    merkle_tree::{Config, Path},
+    merkle_tree::{Config, IdentityDigestConverter, Path},
 };
 use ark_ff::PrimeField;
 use ark_r1cs_std::prelude::*;
@@ -9,15 +9,11 @@ use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_std::vec::Vec;
 use ark_std::{borrow::Borrow, fmt::Debug};
 
-#[cfg(test)]
-use crate::merkle_tree::IdentityDigestConverter;
-
 pub trait DigestVarConverter<From, To: ?Sized> {
     type TargetType: Borrow<To>;
     fn convert(from: From) -> Result<Self::TargetType, SynthesisError>;
 }
 
-#[cfg(test)]
 impl<T> DigestVarConverter<T, T> for IdentityDigestConverter<T> {
     type TargetType = T;
 

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -48,12 +48,10 @@ pub trait DigestConverter<From, To: ?Sized> {
 }
 
 /// A trivial converter where digest of previous layer's hash is the same as next layer's input.
-#[cfg(test)]
 pub struct IdentityDigestConverter<T> {
     _prev_layer_digest: T,
 }
 
-#[cfg(test)]
 impl<T> DigestConverter<T, T> for IdentityDigestConverter<T> {
     type TargetType = T;
     fn convert(item: T) -> Result<T, Error> {

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::needless_range_loop)]
 
-use core::hash::BuildHasherDefault;
-
 /// Defines a trait to chain two types of CRHs.
 use crate::{
     crh::{CRHScheme, TwoToOneCRHScheme},
@@ -11,7 +9,12 @@ use crate::{
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
-use ark_std::{borrow::Borrow, collections::BTreeSet, fmt::Debug, hash::Hash};
+use ark_std::{
+    borrow::Borrow,
+    collections::BTreeSet,
+    fmt::Debug,
+    hash::{BuildHasherDefault, Hash},
+};
 use hashbrown::HashMap;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;


### PR DESCRIPTION
The changes in commit 0960300 were to satisfy CI for the nightly build. It is no longer an issue. Also, it is better to bring the struct `IdentityDigestConverter` back as some users depend on it.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (main)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
