### PR TITLE
Prevent panic in MerkleTree MultiPath::verify by handling missing leaves

### DIFF
--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -278,7 +278,10 @@ impl<P: Config> MultiPath<P> {
 
         for i in 0..self.leaf_indexes.len() {
             let leaf_index = self.leaf_indexes[i];
-            let leaf = leaves.next().unwrap();
+            let leaf = match leaves.next() {
+                Some(l) => l,
+                None => return Err(crate::Error::IncorrectInputLength(self.leaf_indexes.len())),
+            };
             let leaf_sibling_hash = &self.leaf_siblings_hashes[i];
 
             // decode i-th auth path


### PR DESCRIPTION


Description (Markdown):
- What: Replace `unwrap()` in `MultiPath::verify` with explicit check and return `Err(Error::IncorrectInputLength(...))` when the iterator of leaves is shorter than `leaf_indexes.len()`.
- Why: Avoids potential panic/DoS on malformed or adversarial input; aligns with the function’s `Result<bool, Error>` contract; consistent with `Path::verify` behavior.
- Build: `cargo check` passes.
