### PR TITLE
Fix incorrect native field type detection in Poseidon sponge

### DIFF
--- a/crypto-primitives/src/sponge/poseidon/mod.rs
+++ b/crypto-primitives/src/sponge/poseidon/mod.rs
@@ -292,7 +292,9 @@ impl<F: PrimeField> CryptographicSponge for PoseidonSponge<F> {
         &mut self,
         sizes: &[FieldElementSize],
     ) -> Vec<F2> {
-        if F::characteristic() == F2::characteristic() {
+        // Use exact type match for native case to avoid incorrect casts across distinct fields
+        // that share the same field characteristic.
+        if TypeId::of::<F>() == TypeId::of::<F2>() {
             // native case
             let mut buf = Vec::with_capacity(sizes.len());
             field_cast(


### PR DESCRIPTION

## Description

This PR fixes a logical error in the `squeeze_field_elements_with_sizes` method of `PoseidonSponge` where the native field type case was incorrectly determined by comparing field characteristics instead of exact type matching.

**Problem**: The method used `F::characteristic() == F2::characteristic()` to determine if casting between fields was safe, which could lead to incorrect casts when different field types share the same characteristic.

**Solution**: Changed the logic to use `TypeId::of::<F>() == TypeId::of::<F2>()` for exact type matching, aligning with the existing `squeeze_field_elements` method.


