### PR TITLE
Add bit reverse leaf index option

### DIFF
--- a/crypto-primitives/benches/merkle_tree.rs
+++ b/crypto-primitives/benches/merkle_tree.rs
@@ -6,6 +6,7 @@ static NUM_LEAVES: i32 = 1 << 20;
 mod bytes_mt_benches {
     use ark_crypto_primitives::crh::*;
     use ark_crypto_primitives::merkle_tree::*;
+    use ark_crypto_primitives::merkle_tree::LeafOrderingMode;
     use ark_crypto_primitives::to_uncompressed_bytes;
     use ark_ff::BigInteger256;
     use ark_serialize::CanonicalSerialize;
@@ -51,6 +52,7 @@ mod bytes_mt_benches {
                     &leaf_crh_params.clone(),
                     &two_to_one_params.clone(),
                     &leaves,
+                    LeafOrderingMode::NATURAL,
                 )
                 .unwrap();
             })
@@ -74,6 +76,7 @@ mod bytes_mt_benches {
             &leaf_crh_params.clone(),
             &two_to_one_params.clone(),
             &leaves,
+            LeafOrderingMode::NATURAL,
         )
         .unwrap();
         c.bench_function("Merkle Tree Generate Proof (Leaves as [u8])", move |b| {
@@ -102,6 +105,7 @@ mod bytes_mt_benches {
             &leaf_crh_params.clone(),
             &two_to_one_params.clone(),
             &leaves,
+            LeafOrderingMode::NATURAL,
         )
         .unwrap();
 
@@ -141,6 +145,7 @@ mod bytes_mt_benches {
             &leaf_crh_params.clone(),
             &two_to_one_params.clone(),
             &leaves,
+            LeafOrderingMode::NATURAL,
         )
         .unwrap();
         c.bench_function(
@@ -171,6 +176,7 @@ mod bytes_mt_benches {
             &leaf_crh_params.clone(),
             &two_to_one_params.clone(),
             &leaves,
+            LeafOrderingMode::NATURAL,
         )
         .unwrap();
 

--- a/crypto-primitives/benches/merkle_tree.rs
+++ b/crypto-primitives/benches/merkle_tree.rs
@@ -5,8 +5,8 @@ static NUM_LEAVES: i32 = 1 << 20;
 
 mod bytes_mt_benches {
     use ark_crypto_primitives::crh::*;
-    use ark_crypto_primitives::merkle_tree::*;
     use ark_crypto_primitives::merkle_tree::LeafOrderingMode;
+    use ark_crypto_primitives::merkle_tree::*;
     use ark_crypto_primitives::to_uncompressed_bytes;
     use ark_ff::BigInteger256;
     use ark_serialize::CanonicalSerialize;

--- a/crypto-primitives/src/crh/bowe_hopwood/mod.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/mod.rs
@@ -7,10 +7,10 @@ use crate::{
     Error,
 };
 use ark_ec::{
-    twisted_edwards::Projective as TEProjective, twisted_edwards::TECurveConfig,
-    CurveGroup, Group
+    twisted_edwards::Projective as TEProjective, twisted_edwards::TECurveConfig, AdditiveGroup,
+    CurveGroup,
 };
-use ark_ff::{fields::PrimeField, BigInteger};
+use ark_ff::fields::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
@@ -84,7 +84,7 @@ impl<P: TECurveConfig, W: pedersen::Window> CRHScheme for CRH<P, W> {
             let mut c = 0;
             let mut range = F::BigInt::from(2_u64);
             while range < upper_limit {
-                range.muln(4);
+                range <<= 4;
                 c += 1;
             }
 

--- a/crypto-primitives/src/crh/bowe_hopwood/mod.rs
+++ b/crypto-primitives/src/crh/bowe_hopwood/mod.rs
@@ -7,10 +7,10 @@ use crate::{
     Error,
 };
 use ark_ec::{
-    twisted_edwards::Projective as TEProjective, twisted_edwards::TECurveConfig, AdditiveGroup,
-    CurveGroup,
+    twisted_edwards::Projective as TEProjective, twisted_edwards::TECurveConfig,
+    CurveGroup, Group
 };
-use ark_ff::fields::PrimeField;
+use ark_ff::{fields::PrimeField, BigInteger};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 #[cfg(not(feature = "std"))]
 use ark_std::vec::Vec;
@@ -84,7 +84,7 @@ impl<P: TECurveConfig, W: pedersen::Window> CRHScheme for CRH<P, W> {
             let mut c = 0;
             let mut range = F::BigInt::from(2_u64);
             while range < upper_limit {
-                range <<= 4;
+                range.muln(4);
                 c += 1;
             }
 

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -62,6 +62,21 @@ impl<T> DigestConverter<T, T> for IdentityDigestConverter<T> {
     }
 }
 
+#[derive(PartialEq, Clone, Debug, Default, CanonicalSerialize, CanonicalDeserialize)]
+pub struct LeafOrderingMode(u8);
+impl LeafOrderingMode {
+    pub const NATURAL: Self = Self(0);
+    pub const BIT_REVERSED: Self = Self(1);
+    
+    pub fn is_bit_reversed(&self) -> bool {
+        self.0 == 1
+    }
+    
+    pub fn is_natural(&self) -> bool {
+        self.0 == 0
+    }
+}
+
 /// Convert previous layer's digest to bytes and use bytes as input for next layer's digest.
 /// TODO: `ToBytes` trait will be deprecated in future versions.
 pub struct ByteDigestConverter<T: CanonicalSerialize> {
@@ -251,6 +266,8 @@ pub struct MultiPath<P: Config> {
     pub auth_paths_suffixes: Vec<Vec<P::InnerDigest>>,
     /// stores the leaf indexes of the nodes to prove
     pub leaf_indexes: Vec<usize>,
+    /// stores the ordering mode of the leaves
+    pub leaf_ordering_mode: LeafOrderingMode,
 }
 
 impl<P: Config> MultiPath<P> {
@@ -392,6 +409,8 @@ pub struct MerkleTree<P: Config> {
     leaf_hash_param: LeafParam<P>,
     /// Stores the height of the MerkleTree
     height: usize,
+    /// Stores the ordering mode of the leaves
+    leaf_ordering_mode: LeafOrderingMode,
 }
 
 impl<P: Config> MerkleTree<P> {
@@ -401,10 +420,11 @@ impl<P: Config> MerkleTree<P> {
         leaf_hash_param: &LeafParam<P>,
         two_to_one_hash_param: &TwoToOneParam<P>,
         height: usize,
+        leaf_ordering_mode: LeafOrderingMode,
     ) -> Result<Self, crate::Error> {
         // use empty leaf digest
         let leaf_digests = vec![P::LeafDigest::default(); 1 << (height - 1)];
-        Self::new_with_leaf_digest(leaf_hash_param, two_to_one_hash_param, leaf_digests)
+        Self::new_with_leaf_digest(leaf_hash_param, two_to_one_hash_param, leaf_digests, leaf_ordering_mode)
     }
 
     /// Returns a new merkle tree. `leaves.len()` should be power of two.
@@ -413,18 +433,20 @@ impl<P: Config> MerkleTree<P> {
         two_to_one_hash_param: &TwoToOneParam<P>,
         #[cfg(not(feature = "parallel"))] leaves: impl IntoIterator<Item = L>,
         #[cfg(feature = "parallel")] leaves: impl IntoParallelIterator<Item = L>,
+        leaf_ordering_mode: LeafOrderingMode,
     ) -> Result<Self, crate::Error> {
         let leaf_digests: Vec<_> = cfg_into_iter!(leaves)
             .map(|input| P::LeafHash::evaluate(leaf_hash_param, input.as_ref()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Self::new_with_leaf_digest(leaf_hash_param, two_to_one_hash_param, leaf_digests)
+        Self::new_with_leaf_digest(leaf_hash_param, two_to_one_hash_param, leaf_digests, leaf_ordering_mode)
     }
 
     pub fn new_with_leaf_digest(
         leaf_hash_param: &LeafParam<P>,
         two_to_one_hash_param: &TwoToOneParam<P>,
         leaf_digests: Vec<P::LeafDigest>,
+        leaf_ordering_mode: LeafOrderingMode,
     ) -> Result<Self, crate::Error> {
         let leaf_nodes_size = leaf_digests.len();
         assert!(
@@ -469,13 +491,22 @@ impl<P: Config> MerkleTree<P> {
                     let left_leaf_index = left_child(current_index) - upper_bound;
                     let right_leaf_index = right_child(current_index) - upper_bound;
 
+                    let mut left_leaf_physical = left_leaf_index;
+                    let mut right_leaf_physical = right_leaf_index;
+                    
+                    // If needed - apply bit-reversal to access the correct leaf positions
+                    if leaf_ordering_mode.is_bit_reversed() {
+                        left_leaf_physical = bit_reverse_index(left_leaf_index, (tree_height - 1) as u32);
+                        right_leaf_physical = bit_reverse_index(right_leaf_index, (tree_height - 1) as u32);
+                    }
+
                     *n = P::TwoToOneHash::evaluate(
                         two_to_one_hash_param,
                         P::LeafInnerDigestConverter::convert(
-                            leaf_digests[left_leaf_index].clone(),
+                            leaf_digests[left_leaf_physical].clone(),
                         )?,
                         P::LeafInnerDigestConverter::convert(
-                            leaf_digests[right_leaf_index].clone(),
+                            leaf_digests[right_leaf_physical].clone(),
                         )?,
                     )?;
                     Ok::<(), crate::Error>(())
@@ -519,6 +550,7 @@ impl<P: Config> MerkleTree<P> {
             height: tree_height,
             leaf_hash_param: leaf_hash_param.clone(),
             two_to_one_hash_param: two_to_one_hash_param.clone(),
+            leaf_ordering_mode: leaf_ordering_mode,
         })
     }
 
@@ -534,13 +566,18 @@ impl<P: Config> MerkleTree<P> {
 
     /// Given the `index` of a leaf, returns the digest of its leaf sibling
     pub fn get_leaf_sibling_hash(&self, index: usize) -> P::LeafDigest {
-        if index & 1 == 0 {
-            // leaf is left child
-            self.leaf_nodes[index + 1].clone()
+        let sibling_index = if index & 1 == 0 {
+            // leaf is left child, sibling is at index + 1
+            index + 1
         } else {
-            // leaf is right child
-            self.leaf_nodes[index - 1].clone()
+            // leaf is right child, sibling is at index - 1
+            index - 1
+        };
+        let mut physical_index = sibling_index;
+        if self.leaf_ordering_mode.is_bit_reversed() {
+             physical_index = bit_reverse_index(sibling_index, (self.height - 1) as u32);
         }
+        self.leaf_nodes[physical_index].clone()
     }
 
     /// Returns the authentication path from leaf at `index` to root, as a Vec of digests
@@ -578,6 +615,12 @@ impl<P: Config> MerkleTree<P> {
         })
     }
 
+    pub fn reverse_bits(&self, val: usize, bits: u32) -> usize {
+        debug_assert!(val < 2_usize.pow(bits));
+        debug_assert!(bits > 0);
+        // shift will overflow if bits = 0
+        val.reverse_bits() >> (usize::BITS - bits)
+    }
     /// Returns a MultiPath (multiple authentication paths in compressed form, with Front Incremental Encoding),
     /// from every leaf to root.
     /// Note that for compression efficiency, the indexes are internally sorted.
@@ -621,6 +664,7 @@ impl<P: Config> MerkleTree<P> {
             auth_paths_prefix_lenghts,
             auth_paths_suffixes,
             leaf_siblings_hashes,
+            leaf_ordering_mode: self.leaf_ordering_mode.clone(),
         })
     }
 
@@ -637,9 +681,17 @@ impl<P: Config> MerkleTree<P> {
         // calculate leaf sibling hash and locate its position (left or right)
         let (leaf_left, leaf_right) = if index & 1 == 0 {
             // leaf on left
-            (&new_leaf_hash, &self.leaf_nodes[index + 1])
+            let mut sibling_physical = index + 1;
+            if self.leaf_ordering_mode.is_bit_reversed() {
+                sibling_physical = bit_reverse_index(index + 1, (self.height - 1) as u32);
+            }
+            (&new_leaf_hash, &self.leaf_nodes[sibling_physical])
         } else {
-            (&self.leaf_nodes[index - 1], &new_leaf_hash)
+            let mut sibling_physical = index - 1;
+            if self.leaf_ordering_mode.is_bit_reversed() {
+                sibling_physical = bit_reverse_index(index - 1, (self.height - 1) as u32);
+            }
+            (&self.leaf_nodes[sibling_physical], &new_leaf_hash)
         };
 
         // calculate the updated hash at bottom non-leaf-level
@@ -692,7 +744,11 @@ impl<P: Config> MerkleTree<P> {
     pub fn update(&mut self, index: usize, new_leaf: &P::Leaf) -> Result<(), crate::Error> {
         assert!(index < self.leaf_nodes.len(), "index out of range");
         let (updated_leaf_hash, mut updated_path) = self.updated_path(index, new_leaf)?;
-        self.leaf_nodes[index] = updated_leaf_hash;
+        let mut physical_index = index;
+        if self.leaf_ordering_mode.is_bit_reversed() {
+            physical_index = bit_reverse_index(index, (self.height - 1) as u32);
+        }
+        self.leaf_nodes[physical_index] = updated_leaf_hash;
         let mut curr_index = convert_index_to_last_level(index, self.height);
         for _ in 0..self.height - 1 {
             curr_index = parent(curr_index).unwrap();
@@ -715,7 +771,11 @@ impl<P: Config> MerkleTree<P> {
         if &updated_path[0] != asserted_new_root {
             return Ok(false);
         }
-        self.leaf_nodes[index] = updated_leaf_hash;
+        let mut physical_index = index;
+        if self.leaf_ordering_mode.is_bit_reversed() {
+            physical_index = bit_reverse_index(index, (self.height - 1) as u32);
+        }
+        self.leaf_nodes[physical_index] = updated_leaf_hash;
         let mut curr_index = convert_index_to_last_level(index, self.height);
         for _ in 0..self.height - 1 {
             curr_index = parent(curr_index).unwrap();
@@ -783,6 +843,16 @@ fn parent(index: usize) -> Option<usize> {
 #[inline]
 fn convert_index_to_last_level(index: usize, tree_height: usize) -> usize {
     index + (1 << (tree_height - 1)) - 1
+}
+
+/// Converts a logical index to a physical index using bit-reversal
+#[inline]
+fn bit_reverse_index(index: usize, height: u32) -> usize {
+    if height == 0 {
+        index
+    } else {
+        index.reverse_bits() >> (usize::BITS - height)
+    }
 }
 
 /// Encodes path with Incremental Encoding by comparing with prev_path

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -615,12 +615,6 @@ impl<P: Config> MerkleTree<P> {
         })
     }
 
-    pub fn reverse_bits(&self, val: usize, bits: u32) -> usize {
-        debug_assert!(val < 2_usize.pow(bits));
-        debug_assert!(bits > 0);
-        // shift will overflow if bits = 0
-        val.reverse_bits() >> (usize::BITS - bits)
-    }
     /// Returns a MultiPath (multiple authentication paths in compressed form, with Front Incremental Encoding),
     /// from every leaf to root.
     /// Note that for compression efficiency, the indexes are internally sorted.

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -67,11 +67,11 @@ pub struct LeafOrderingMode(u8);
 impl LeafOrderingMode {
     pub const NATURAL: Self = Self(0);
     pub const BIT_REVERSED: Self = Self(1);
-    
+
     pub fn is_bit_reversed(&self) -> bool {
         self.0 == 1
     }
-    
+
     pub fn is_natural(&self) -> bool {
         self.0 == 0
     }
@@ -424,7 +424,12 @@ impl<P: Config> MerkleTree<P> {
     ) -> Result<Self, crate::Error> {
         // use empty leaf digest
         let leaf_digests = vec![P::LeafDigest::default(); 1 << (height - 1)];
-        Self::new_with_leaf_digest(leaf_hash_param, two_to_one_hash_param, leaf_digests, leaf_ordering_mode)
+        Self::new_with_leaf_digest(
+            leaf_hash_param,
+            two_to_one_hash_param,
+            leaf_digests,
+            leaf_ordering_mode,
+        )
     }
 
     /// Returns a new merkle tree. `leaves.len()` should be power of two.
@@ -439,7 +444,12 @@ impl<P: Config> MerkleTree<P> {
             .map(|input| P::LeafHash::evaluate(leaf_hash_param, input.as_ref()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Self::new_with_leaf_digest(leaf_hash_param, two_to_one_hash_param, leaf_digests, leaf_ordering_mode)
+        Self::new_with_leaf_digest(
+            leaf_hash_param,
+            two_to_one_hash_param,
+            leaf_digests,
+            leaf_ordering_mode,
+        )
     }
 
     pub fn new_with_leaf_digest(
@@ -493,11 +503,13 @@ impl<P: Config> MerkleTree<P> {
 
                     let mut left_leaf_physical = left_leaf_index;
                     let mut right_leaf_physical = right_leaf_index;
-                    
+
                     // If needed - apply bit-reversal to access the correct leaf positions
                     if leaf_ordering_mode.is_bit_reversed() {
-                        left_leaf_physical = bit_reverse_index(left_leaf_index, (tree_height - 1) as u32);
-                        right_leaf_physical = bit_reverse_index(right_leaf_index, (tree_height - 1) as u32);
+                        left_leaf_physical =
+                            bit_reverse_index(left_leaf_index, (tree_height - 1) as u32);
+                        right_leaf_physical =
+                            bit_reverse_index(right_leaf_index, (tree_height - 1) as u32);
                     }
 
                     *n = P::TwoToOneHash::evaluate(
@@ -575,7 +587,7 @@ impl<P: Config> MerkleTree<P> {
         };
         let mut physical_index = sibling_index;
         if self.leaf_ordering_mode.is_bit_reversed() {
-             physical_index = bit_reverse_index(sibling_index, (self.height - 1) as u32);
+            physical_index = bit_reverse_index(sibling_index, (self.height - 1) as u32);
         }
         self.leaf_nodes[physical_index].clone()
     }

--- a/crypto-primitives/src/merkle_tree/tests/constraints.rs
+++ b/crypto-primitives/src/merkle_tree/tests/constraints.rs
@@ -4,7 +4,7 @@ mod byte_mt_tests {
     };
     use crate::merkle_tree::{
         constraints::{BytesVarDigestConverter, ConfigGadget, PathVar},
-        ByteDigestConverter, Config, MerkleTree,
+        ByteDigestConverter, Config, LeafOrderingMode, MerkleTree,
     };
     use ark_ed_on_bls12_381::{constraints::EdwardsVar, EdwardsProjective as JubJub, Fq};
     use ark_r1cs_std::prelude::*;
@@ -62,7 +62,7 @@ mod byte_mt_tests {
         let leaf_crh_params = <LeafH as CRHScheme>::setup(&mut rng).unwrap();
         let two_to_one_crh_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng).unwrap();
         let mut tree =
-            JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_crh_params, leaves).unwrap();
+            JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_crh_params, leaves, LeafOrderingMode::NATURAL).unwrap();
         let root = tree.root();
         for (i, leaf) in leaves.iter().enumerate() {
             let cs = ConstraintSystem::<Fq>::new_ref();
@@ -239,7 +239,7 @@ mod field_mt_tests {
     use crate::merkle_tree::{
         constraints::{ConfigGadget, PathVar},
         tests::test_utils::poseidon_parameters,
-        Config, IdentityDigestConverter, MerkleTree,
+        Config, IdentityDigestConverter, LeafOrderingMode, MerkleTree,
     };
     use ark_r1cs_std::{
         alloc::AllocVar, convert::ToBitsGadget, fields::fp::FpVar, uint32::UInt32, R1CSVar,
@@ -285,7 +285,7 @@ mod field_mt_tests {
     ) {
         let leaf_crh_params = poseidon_parameters();
         let two_to_one_params = leaf_crh_params.clone();
-        let mut tree = FieldMT::new(&leaf_crh_params, &two_to_one_params, leaves).unwrap();
+        let mut tree = FieldMT::new(&leaf_crh_params, &two_to_one_params, leaves, LeafOrderingMode::NATURAL).unwrap();
         let root = tree.root();
         for (i, leaf) in leaves.iter().enumerate() {
             let cs = ConstraintSystem::<F>::new_ref();

--- a/crypto-primitives/src/merkle_tree/tests/constraints.rs
+++ b/crypto-primitives/src/merkle_tree/tests/constraints.rs
@@ -61,8 +61,13 @@ mod byte_mt_tests {
 
         let leaf_crh_params = <LeafH as CRHScheme>::setup(&mut rng).unwrap();
         let two_to_one_crh_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng).unwrap();
-        let mut tree =
-            JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_crh_params, leaves, LeafOrderingMode::NATURAL).unwrap();
+        let mut tree = JubJubMerkleTree::new(
+            &leaf_crh_params,
+            &two_to_one_crh_params,
+            leaves,
+            LeafOrderingMode::NATURAL,
+        )
+        .unwrap();
         let root = tree.root();
         for (i, leaf) in leaves.iter().enumerate() {
             let cs = ConstraintSystem::<Fq>::new_ref();
@@ -285,7 +290,13 @@ mod field_mt_tests {
     ) {
         let leaf_crh_params = poseidon_parameters();
         let two_to_one_params = leaf_crh_params.clone();
-        let mut tree = FieldMT::new(&leaf_crh_params, &two_to_one_params, leaves, LeafOrderingMode::NATURAL).unwrap();
+        let mut tree = FieldMT::new(
+            &leaf_crh_params,
+            &two_to_one_params,
+            leaves,
+            LeafOrderingMode::NATURAL,
+        )
+        .unwrap();
         let root = tree.root();
         for (i, leaf) in leaves.iter().enumerate() {
             let cs = ConstraintSystem::<F>::new_ref();

--- a/crypto-primitives/src/merkle_tree/tests/mod.rs
+++ b/crypto-primitives/src/merkle_tree/tests/mod.rs
@@ -46,7 +46,7 @@ mod bytes_mt_tests {
         let two_to_one_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng).unwrap();
 
         let mut tree =
-            JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_params, &leaves).unwrap();
+            JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_params, &leaves, LeafOrderingMode::NATURAL).unwrap();
 
         let mut root = tree.root();
         // test merkle tree functionality without update
@@ -148,7 +148,7 @@ mod bytes_mt_tests {
         let leaf_crh_params = <LeafH as CRHScheme>::setup(&mut rng).unwrap();
         let two_to_one_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng).unwrap();
 
-        let tree = JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_params, &serialized_leaves)
+        let tree = JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_params, &serialized_leaves, LeafOrderingMode::NATURAL)
             .unwrap();
 
         let mut proofs = Vec::with_capacity(leaves.len());
@@ -212,7 +212,7 @@ mod field_mt_tests {
         let leaf_crh_params = poseidon_parameters();
         let two_to_one_params = leaf_crh_params.clone();
 
-        let mut tree = FieldMT::new(&leaf_crh_params, &two_to_one_params, &leaves).unwrap();
+        let mut tree = FieldMT::new(&leaf_crh_params, &two_to_one_params, &leaves, LeafOrderingMode::NATURAL).unwrap();
 
         let mut root = tree.root();
 

--- a/crypto-primitives/src/merkle_tree/tests/mod.rs
+++ b/crypto-primitives/src/merkle_tree/tests/mod.rs
@@ -4,11 +4,11 @@ mod test_utils;
 
 mod bytes_mt_tests {
 
+    use crate::merkle_tree::LeafOrderingMode;
     use crate::{crh::*, merkle_tree::*};
     use ark_ed_on_bls12_381::EdwardsProjective as JubJub;
     use ark_ff::BigInteger256;
     use ark_std::{iter::zip, test_rng, UniformRand};
-    use crate::merkle_tree::LeafOrderingMode;
 
     #[derive(Clone)]
     pub(super) struct Window4x256;
@@ -46,8 +46,13 @@ mod bytes_mt_tests {
         let leaf_crh_params = <LeafH as CRHScheme>::setup(&mut rng).unwrap();
         let two_to_one_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng).unwrap();
 
-        let mut tree =
-            JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_params, &leaves, LeafOrderingMode::NATURAL).unwrap();
+        let mut tree = JubJubMerkleTree::new(
+            &leaf_crh_params,
+            &two_to_one_params,
+            &leaves,
+            LeafOrderingMode::NATURAL,
+        )
+        .unwrap();
 
         let mut root = tree.root();
         // test merkle tree functionality without update
@@ -149,8 +154,13 @@ mod bytes_mt_tests {
         let leaf_crh_params = <LeafH as CRHScheme>::setup(&mut rng).unwrap();
         let two_to_one_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng).unwrap();
 
-        let tree = JubJubMerkleTree::new(&leaf_crh_params, &two_to_one_params, &serialized_leaves, LeafOrderingMode::NATURAL)
-            .unwrap();
+        let tree = JubJubMerkleTree::new(
+            &leaf_crh_params,
+            &two_to_one_params,
+            &serialized_leaves,
+            LeafOrderingMode::NATURAL,
+        )
+        .unwrap();
 
         let mut proofs = Vec::with_capacity(leaves.len());
 
@@ -227,14 +237,26 @@ mod bytes_mt_tests {
             // Natural ordering proof
             let proof_natural = tree_natural.generate_proof(i).unwrap();
             assert!(proof_natural
-                .verify(&leaf_crh_params, &two_to_one_params, &tree_natural.root(), leaf.as_slice())
+                .verify(
+                    &leaf_crh_params,
+                    &two_to_one_params,
+                    &tree_natural.root(),
+                    leaf.as_slice()
+                )
                 .unwrap());
 
             // Bit-reversed ordering proof
             let proof_bit_reversed = tree_bit_reversed.generate_proof(i).unwrap();
-            let actual_leaf = serialized_leaves[bit_reverse_index(i, (tree_bit_reversed.height() - 1) as u32)].clone();
+            let actual_leaf = serialized_leaves
+                [bit_reverse_index(i, (tree_bit_reversed.height() - 1) as u32)]
+            .clone();
             assert!(proof_bit_reversed
-                .verify(&leaf_crh_params, &two_to_one_params, &tree_bit_reversed.root(), actual_leaf.as_slice())
+                .verify(
+                    &leaf_crh_params,
+                    &two_to_one_params,
+                    &tree_bit_reversed.root(),
+                    actual_leaf.as_slice()
+                )
                 .unwrap());
         }
 
@@ -243,19 +265,35 @@ mod bytes_mt_tests {
             .generate_multi_proof((0..serialized_leaves.len()).collect::<Vec<_>>())
             .unwrap();
         assert!(multi_proof_natural
-            .verify(&leaf_crh_params, &two_to_one_params, &tree_natural.root(), serialized_leaves.clone())
+            .verify(
+                &leaf_crh_params,
+                &two_to_one_params,
+                &tree_natural.root(),
+                serialized_leaves.clone()
+            )
             .unwrap());
 
         let multi_proof_bit_reversed = tree_bit_reversed
             .generate_multi_proof((0..serialized_leaves.len()).collect::<Vec<_>>())
             .unwrap();
         assert!(multi_proof_bit_reversed
-            .verify(&leaf_crh_params, &two_to_one_params, &tree_bit_reversed.root(), serialized_leaves.clone())
+            .verify(
+                &leaf_crh_params,
+                &two_to_one_params,
+                &tree_bit_reversed.root(),
+                serialized_leaves.clone()
+            )
             .unwrap());
 
         // Verify the ordering mode is stored correctly in multi-proofs
-        assert_eq!(multi_proof_natural.leaf_ordering_mode, LeafOrderingMode::NATURAL);
-        assert_eq!(multi_proof_bit_reversed.leaf_ordering_mode, LeafOrderingMode::BIT_REVERSED);
+        assert_eq!(
+            multi_proof_natural.leaf_ordering_mode,
+            LeafOrderingMode::NATURAL
+        );
+        assert_eq!(
+            multi_proof_bit_reversed.leaf_ordering_mode,
+            LeafOrderingMode::BIT_REVERSED
+        );
     }
 
     #[test]
@@ -270,9 +308,9 @@ mod bytes_mt_tests {
         // 5 (101) -> 5 (101)
         // 6 (110) -> 3 (011)
         // 7 (111) -> 7 (111)
-        
+
         use crate::merkle_tree::bit_reverse_index;
-        
+
         let height = 3u32;
         assert_eq!(bit_reverse_index(0, height), 0);
         assert_eq!(bit_reverse_index(1, height), 4);
@@ -299,7 +337,8 @@ mod field_mt_tests {
     use crate::{
         crh::poseidon,
         merkle_tree::{
-            tests::test_utils::poseidon_parameters, Config, IdentityDigestConverter, MerkleTree, LeafOrderingMode
+            tests::test_utils::poseidon_parameters, Config, IdentityDigestConverter,
+            LeafOrderingMode, MerkleTree,
         },
     };
     use ark_std::{test_rng, One, UniformRand};
@@ -325,7 +364,13 @@ mod field_mt_tests {
         let leaf_crh_params = poseidon_parameters();
         let two_to_one_params = leaf_crh_params.clone();
 
-        let mut tree = FieldMT::new(&leaf_crh_params, &two_to_one_params, &leaves, LeafOrderingMode::NATURAL).unwrap();
+        let mut tree = FieldMT::new(
+            &leaf_crh_params,
+            &two_to_one_params,
+            &leaves,
+            LeafOrderingMode::NATURAL,
+        )
+        .unwrap();
 
         let mut root = tree.root();
 

--- a/crypto-primitives/src/merkle_tree/tests/mod.rs
+++ b/crypto-primitives/src/merkle_tree/tests/mod.rs
@@ -8,6 +8,7 @@ mod bytes_mt_tests {
     use ark_ed_on_bls12_381::EdwardsProjective as JubJub;
     use ark_ff::BigInteger256;
     use ark_std::{iter::zip, test_rng, UniformRand};
+    use crate::merkle_tree::LeafOrderingMode;
 
     #[derive(Clone)]
     pub(super) struct Window4x256;
@@ -180,13 +181,125 @@ mod bytes_mt_tests {
             assert_eq!(prefix_len + suffix.len(), proofs[0].auth_path.len());
         }
     }
+
+    #[test]
+    fn bit_reversed_ordering_test() {
+        use ark_serialize::CanonicalSerialize;
+        let mut rng = test_rng();
+
+        // Create test leaves with distinct values
+        let mut leaves = Vec::new();
+        for i in 0..8u8 {
+            leaves.push(BigInteger256::from(i as u64));
+        }
+
+        let serialized_leaves: Vec<_> = leaves
+            .iter()
+            .map(|leaf| crate::to_uncompressed_bytes!(leaf).unwrap())
+            .collect();
+
+        let leaf_crh_params = <LeafH as CRHScheme>::setup(&mut rng).unwrap();
+        let two_to_one_params = <CompressH as TwoToOneCRHScheme>::setup(&mut rng).unwrap();
+
+        // Create two trees: one with natural ordering, one with bit-reversed ordering
+        let tree_natural = JubJubMerkleTree::new(
+            &leaf_crh_params,
+            &two_to_one_params,
+            &serialized_leaves,
+            LeafOrderingMode::NATURAL,
+        )
+        .unwrap();
+
+        let tree_bit_reversed = JubJubMerkleTree::new(
+            &leaf_crh_params,
+            &two_to_one_params,
+            &serialized_leaves,
+            LeafOrderingMode::BIT_REVERSED,
+        )
+        .unwrap();
+
+        // NOTE: The roots will be DIFFERENT because the physical leaf arrangement is different
+        // This is expected and correct behavior
+        assert_ne!(tree_natural.root(), tree_bit_reversed.root());
+
+        // Test that proofs work correctly for both ordering modes
+        for (i, leaf) in serialized_leaves.iter().enumerate() {
+            // Natural ordering proof
+            let proof_natural = tree_natural.generate_proof(i).unwrap();
+            assert!(proof_natural
+                .verify(&leaf_crh_params, &two_to_one_params, &tree_natural.root(), leaf.as_slice())
+                .unwrap());
+
+            // Bit-reversed ordering proof
+            let proof_bit_reversed = tree_bit_reversed.generate_proof(i).unwrap();
+            let actual_leaf = serialized_leaves[bit_reverse_index(i, (tree_bit_reversed.height() - 1) as u32)].clone();
+            assert!(proof_bit_reversed
+                .verify(&leaf_crh_params, &two_to_one_params, &tree_bit_reversed.root(), actual_leaf.as_slice())
+                .unwrap());
+        }
+
+        // Test multi-proofs work with bit-reversed ordering
+        let multi_proof_natural = tree_natural
+            .generate_multi_proof((0..serialized_leaves.len()).collect::<Vec<_>>())
+            .unwrap();
+        assert!(multi_proof_natural
+            .verify(&leaf_crh_params, &two_to_one_params, &tree_natural.root(), serialized_leaves.clone())
+            .unwrap());
+
+        let multi_proof_bit_reversed = tree_bit_reversed
+            .generate_multi_proof((0..serialized_leaves.len()).collect::<Vec<_>>())
+            .unwrap();
+        assert!(multi_proof_bit_reversed
+            .verify(&leaf_crh_params, &two_to_one_params, &tree_bit_reversed.root(), serialized_leaves.clone())
+            .unwrap());
+
+        // Verify the ordering mode is stored correctly in multi-proofs
+        assert_eq!(multi_proof_natural.leaf_ordering_mode, LeafOrderingMode::NATURAL);
+        assert_eq!(multi_proof_bit_reversed.leaf_ordering_mode, LeafOrderingMode::BIT_REVERSED);
+    }
+
+    #[test]
+    fn bit_reverse_index_test() {
+        // Test the bit_reverse_index function directly
+        // For height=3 (8 leaves), indices should be:
+        // 0 (000) -> 0 (000)
+        // 1 (001) -> 4 (100)
+        // 2 (010) -> 2 (010)
+        // 3 (011) -> 6 (110)
+        // 4 (100) -> 1 (001)
+        // 5 (101) -> 5 (101)
+        // 6 (110) -> 3 (011)
+        // 7 (111) -> 7 (111)
+        
+        use crate::merkle_tree::bit_reverse_index;
+        
+        let height = 3u32;
+        assert_eq!(bit_reverse_index(0, height), 0);
+        assert_eq!(bit_reverse_index(1, height), 4);
+        assert_eq!(bit_reverse_index(2, height), 2);
+        assert_eq!(bit_reverse_index(3, height), 6);
+        assert_eq!(bit_reverse_index(4, height), 1);
+        assert_eq!(bit_reverse_index(5, height), 5);
+        assert_eq!(bit_reverse_index(6, height), 3);
+        assert_eq!(bit_reverse_index(7, height), 7);
+
+        // Test with height=2 (4 leaves)
+        let height = 2u32;
+        assert_eq!(bit_reverse_index(0, height), 0);
+        assert_eq!(bit_reverse_index(1, height), 2);
+        assert_eq!(bit_reverse_index(2, height), 1);
+        assert_eq!(bit_reverse_index(3, height), 3);
+
+        // Test edge case: height=0 should return the same index
+        assert_eq!(bit_reverse_index(5, 0), 5);
+    }
 }
 
 mod field_mt_tests {
     use crate::{
         crh::poseidon,
         merkle_tree::{
-            tests::test_utils::poseidon_parameters, Config, IdentityDigestConverter, MerkleTree,
+            tests::test_utils::poseidon_parameters, Config, IdentityDigestConverter, MerkleTree, LeafOrderingMode
         },
     };
     use ark_std::{test_rng, One, UniformRand};


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR introduces an option to select if your leaves are accessed by regular or a bit-reverse order of the index.
This feature is needed in certain cases, eg. committing to the results of NTT and the reordering of the leaves is too costly to perform before the commitment. 


----
- [x] Targeted PR against correct branch (main)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
