### PR TITLE
fix: replace append with extend_from_slice in curve point serialization

### DIFF
--- a/crypto-primitives/src/sponge/absorb.rs
+++ b/crypto-primitives/src/sponge/absorb.rs
@@ -252,7 +252,8 @@ where
             .into_iter()
             .chain(self.y.to_field_elements().unwrap())
             .for_each(|elem| {
-                dest.append(&mut elem.into_bigint().to_bytes_le());
+                let bytes = elem.into_bigint().to_bytes_le();
+                dest.extend_from_slice(&bytes);
             });
     }
 
@@ -272,7 +273,8 @@ where
             .into_iter()
             .chain(self.y.to_field_elements().unwrap())
             .for_each(|elem| {
-                dest.append(&mut elem.into_bigint().to_bytes_le());
+                let bytes = elem.into_bigint().to_bytes_le();
+                dest.extend_from_slice(&bytes);
             });
         dest.push(self.is_zero().into());
     }


### PR DESCRIPTION
### Motivation
TEAffine and SWAffine use Vec::append() in loops, which is inconsistent with the rest of the codebase. Other implementations (poseidon, rescue, and other Absorb types) use extend_from_slice().
### Solution
Replaced append(&mut vec) with extend_from_slice(&vec) in both TEAffine::to_sponge_bytes and SWAffine::to_sponge_bytes to match the established pattern.