### PR TITLE
Boilerplate for blake3, poseidon merkle trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- [\#XXX](https://github.com/arkworks-rs/crypto-primitives/pull/XXX) Add boilerplate for BLAKE3 (feature gated) and Poseidon Merkle tree configs.
+
 ### Improvements
 
 ### Bugfixes

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -26,7 +26,7 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-featur
 ark-snark = { git = "https://github.com/arkworks-rs/snark.git", default-features = false }
 
 blake2 = { version = "0.10", default-features = false }
-blake3 = { version = "1", default-features = false }
+blake3 = { version = "1", default-features = false, optional = true }
 sha2 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false }
 merlin = { version = "3.0.0", default-features = false, optional = true }
@@ -40,7 +40,7 @@ hashbrown = { version = "0.15", default-features = false, features = [ "inline-m
 
 [features]
 default = ["std"]
-std = ["ark-ff/std", "ark-ec/std", "ark-std/std", "ark-relations/std", "ark-r1cs-std?/std", "blake3/std" ]
+std = ["ark-ff/std", "ark-ec/std", "ark-std/std", "ark-relations/std", "ark-r1cs-std?/std", "blake3?/std" ]
 print-trace = ["ark-std/print-trace"]
 parallel = [
     "std",

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -26,6 +26,7 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-featur
 ark-snark = { git = "https://github.com/arkworks-rs/snark.git", default-features = false }
 
 blake2 = { version = "0.10", default-features = false }
+blake3 = { version = "1", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false }
 merlin = { version = "3.0.0", default-features = false, optional = true }
@@ -39,7 +40,7 @@ hashbrown = { version = "0.15", default-features = false, features = [ "inline-m
 
 [features]
 default = ["std"]
-std = ["ark-ff/std", "ark-ec/std", "ark-std/std", "ark-relations/std", "ark-r1cs-std?/std" ]
+std = ["ark-ff/std", "ark-ec/std", "ark-std/std", "ark-relations/std", "ark-r1cs-std?/std", "blake3/std" ]
 print-trace = ["ark-std/print-trace"]
 parallel = [
     "std",

--- a/crypto-primitives/src/crh/blake3/crh.rs
+++ b/crypto-primitives/src/crh/blake3/crh.rs
@@ -74,13 +74,13 @@ impl TwoToOneCRHScheme for Blake3TwoToOneCRH {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ark_std::rand::thread_rng;
+    use ark_std::test_rng;
 
     type F = ark_ed_on_bls12_381::Fr;
 
     #[test]
     fn blake3_crh_deterministic() {
-        let params = Blake3CRH::<F>::setup(&mut thread_rng()).unwrap();
+        let params = Blake3CRH::<F>::setup(&mut test_rng()).unwrap();
         let input = vec![F::from(42u64), F::from(99u64)];
 
         let h1 = Blake3CRH::<F>::evaluate(&params, input.as_slice()).unwrap();
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn blake3_crh_different_inputs() {
-        let params = Blake3CRH::<F>::setup(&mut thread_rng()).unwrap();
+        let params = Blake3CRH::<F>::setup(&mut test_rng()).unwrap();
         let a = vec![F::from(1u64)];
         let b = vec![F::from(2u64)];
 
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn blake3_two_to_one_deterministic() {
-        let params = Blake3TwoToOneCRH::setup(&mut thread_rng()).unwrap();
+        let params = Blake3TwoToOneCRH::setup(&mut test_rng()).unwrap();
         let left = ByteDigest([1u8; 32]);
         let right = ByteDigest([2u8; 32]);
 
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn blake3_compress_matches_evaluate() {
-        let params = Blake3TwoToOneCRH::setup(&mut thread_rng()).unwrap();
+        let params = Blake3TwoToOneCRH::setup(&mut test_rng()).unwrap();
         let left = ByteDigest([0xAA; 32]);
         let right = ByteDigest([0xBB; 32]);
 

--- a/crypto-primitives/src/crh/blake3/crh.rs
+++ b/crypto-primitives/src/crh/blake3/crh.rs
@@ -1,0 +1,126 @@
+use ark_ff::Field;
+use ark_serialize::CanonicalSerialize;
+use ark_std::{borrow::Borrow, rand::Rng};
+use core::marker::PhantomData;
+
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
+
+use crate::{
+    crh::{ByteDigest, CRHScheme, TwoToOneCRHScheme},
+    Error,
+};
+
+// Blake3 CRH over field elements.
+// Serializes field elements to bytes and hashes them resulting in a 32 byte digest.
+#[derive(Clone)]
+pub struct Blake3CRH<F: Field> {
+    _f: PhantomData<F>,
+}
+
+impl<F: Field> CRHScheme for Blake3CRH<F> {
+    type Input = [F];
+    type Output = ByteDigest<32>;
+    type Parameters = ();
+
+    fn setup<R: Rng>(_: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(())
+    }
+
+    fn evaluate<T: Borrow<Self::Input>>(
+        (): &Self::Parameters,
+        input: T,
+    ) -> Result<Self::Output, Error> {
+        let mut buf = Vec::new();
+        input.borrow().serialize_compressed(&mut buf)?;
+        Ok(ByteDigest(*blake3::hash(&buf).as_bytes()))
+    }
+}
+
+// Blake3 two-to-one CRH for internal Merkle tree nodes.
+// Hashes `left || right` using BLAKE3, producing a 32-byte digest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Blake3TwoToOneCRH;
+
+impl TwoToOneCRHScheme for Blake3TwoToOneCRH {
+    type Input = ByteDigest<32>;
+    type Output = ByteDigest<32>;
+    type Parameters = ();
+
+    fn setup<R: Rng>(_: &mut R) -> Result<Self::Parameters, Error> {
+        Ok(())
+    }
+
+    fn evaluate<T: Borrow<Self::Input>>(
+        (): &Self::Parameters,
+        left_input: T,
+        right_input: T,
+    ) -> Result<Self::Output, Error> {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&left_input.borrow().0);
+        hasher.update(&right_input.borrow().0);
+        Ok(ByteDigest(*hasher.finalize().as_bytes()))
+    }
+
+    fn compress<T: Borrow<Self::Output>>(
+        parameters: &Self::Parameters,
+        left_input: T,
+        right_input: T,
+    ) -> Result<Self::Output, Error> {
+        Self::evaluate(parameters, left_input, right_input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_std::rand::thread_rng;
+
+    type F = ark_ed_on_bls12_381::Fr;
+
+    #[test]
+    fn blake3_crh_deterministic() {
+        let params = Blake3CRH::<F>::setup(&mut thread_rng()).unwrap();
+        let input = vec![F::from(42u64), F::from(99u64)];
+
+        let h1 = Blake3CRH::<F>::evaluate(&params, input.as_slice()).unwrap();
+        let h2 = Blake3CRH::<F>::evaluate(&params, input.as_slice()).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn blake3_crh_different_inputs() {
+        let params = Blake3CRH::<F>::setup(&mut thread_rng()).unwrap();
+        let a = vec![F::from(1u64)];
+        let b = vec![F::from(2u64)];
+
+        let ha = Blake3CRH::<F>::evaluate(&params, a.as_slice()).unwrap();
+        let hb = Blake3CRH::<F>::evaluate(&params, b.as_slice()).unwrap();
+        assert_ne!(ha, hb);
+    }
+
+    #[test]
+    fn blake3_two_to_one_deterministic() {
+        let params = Blake3TwoToOneCRH::setup(&mut thread_rng()).unwrap();
+        let left = ByteDigest([1u8; 32]);
+        let right = ByteDigest([2u8; 32]);
+
+        let h1 = Blake3TwoToOneCRH::evaluate(&params, &left, &right).unwrap();
+        let h2 = Blake3TwoToOneCRH::evaluate(&params, &left, &right).unwrap();
+        assert_eq!(h1, h2);
+
+        let h3 = Blake3TwoToOneCRH::evaluate(&params, &right, &left).unwrap();
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn blake3_compress_matches_evaluate() {
+        let params = Blake3TwoToOneCRH::setup(&mut thread_rng()).unwrap();
+        let left = ByteDigest([0xAA; 32]);
+        let right = ByteDigest([0xBB; 32]);
+
+        let eval = Blake3TwoToOneCRH::evaluate(&params, &left, &right).unwrap();
+        let comp = Blake3TwoToOneCRH::compress(&params, &left, &right).unwrap();
+        assert_eq!(eval, comp);
+    }
+}

--- a/crypto-primitives/src/crh/blake3/mod.rs
+++ b/crypto-primitives/src/crh/blake3/mod.rs
@@ -1,0 +1,2 @@
+mod crh;
+pub use crh::{Blake3CRH, Blake3TwoToOneCRH};

--- a/crypto-primitives/src/crh/byte_digest.rs
+++ b/crypto-primitives/src/crh/byte_digest.rs
@@ -1,6 +1,9 @@
 use crate::sponge::Absorb;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
+#[cfg(not(feature = "std"))]
+use ark_std::vec::Vec;
+
 // Some CRHs output byte arrays.
 
 // Merkle tree Config requires a trait that implements the following functions.

--- a/crypto-primitives/src/crh/byte_digest.rs
+++ b/crypto-primitives/src/crh/byte_digest.rs
@@ -1,0 +1,38 @@
+use crate::sponge::Absorb;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+// Some CRHs output byte arrays.
+
+// Merkle tree Config requires a trait that implements the following functions.
+// As far as I can tell (z-tech), this is the thinnest possible trait that satisfies the requirements.
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ByteDigest<const N: usize>(pub [u8; N]);
+
+impl<const N: usize> Default for ByteDigest<N> {
+    fn default() -> Self {
+        Self([0; N])
+    }
+}
+
+impl<const N: usize> AsRef<[u8]> for ByteDigest<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for ByteDigest<N> {
+    fn from(value: [u8; N]) -> Self {
+        Self(value)
+    }
+}
+
+impl<const N: usize> Absorb for ByteDigest<N> {
+    fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
+        dest.extend_from_slice(&self.0);
+    }
+
+    fn to_sponge_field_elements<F: ark_ff::PrimeField>(&self, dest: &mut Vec<F>) {
+        dest.push(F::from_be_bytes_mod_order(&self.0));
+    }
+}

--- a/crypto-primitives/src/crh/mod.rs
+++ b/crypto-primitives/src/crh/mod.rs
@@ -3,7 +3,10 @@ use crate::Error;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{borrow::Borrow, fmt::Debug, hash::Hash, rand::Rng};
 
+pub mod blake3;
 pub mod bowe_hopwood;
+pub mod byte_digest;
+pub use byte_digest::ByteDigest;
 #[cfg(feature = "constraints")]
 pub mod constraints;
 pub mod injective_map;

--- a/crypto-primitives/src/crh/mod.rs
+++ b/crypto-primitives/src/crh/mod.rs
@@ -3,6 +3,7 @@ use crate::Error;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{borrow::Borrow, fmt::Debug, hash::Hash, rand::Rng};
 
+#[cfg(feature = "blake3")]
 pub mod blake3;
 pub mod bowe_hopwood;
 pub mod byte_digest;

--- a/crypto-primitives/src/merkle_tree/configs/blake3.rs
+++ b/crypto-primitives/src/merkle_tree/configs/blake3.rs
@@ -1,0 +1,21 @@
+use crate::crh::blake3::{Blake3CRH, Blake3TwoToOneCRH};
+use crate::crh::{CRHScheme, TwoToOneCRHScheme};
+use crate::merkle_tree::{Config, IdentityDigestConverter};
+use ark_ff::Field;
+use ark_std::marker::PhantomData;
+
+// Common config for a Merkle Tree using Blake3 (as seen in STIR, WHIR, WARP etc.)
+
+#[derive(Clone)]
+pub struct Blake3MerkleConfig<F: Field> {
+    _field: PhantomData<F>,
+}
+
+impl<F: Field> Config for Blake3MerkleConfig<F> {
+    type Leaf = [F];
+    type LeafDigest = <Self::LeafHash as CRHScheme>::Output;
+    type LeafInnerDigestConverter = IdentityDigestConverter<Self::LeafDigest>;
+    type InnerDigest = <Self::TwoToOneHash as TwoToOneCRHScheme>::Output;
+    type LeafHash = Blake3CRH<F>;
+    type TwoToOneHash = Blake3TwoToOneCRH;
+}

--- a/crypto-primitives/src/merkle_tree/configs/mod.rs
+++ b/crypto-primitives/src/merkle_tree/configs/mod.rs
@@ -1,0 +1,5 @@
+mod blake3;
+mod poseidon;
+
+pub use blake3::Blake3MerkleConfig;
+pub use poseidon::PoseidonMerkleConfig;

--- a/crypto-primitives/src/merkle_tree/configs/mod.rs
+++ b/crypto-primitives/src/merkle_tree/configs/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "blake3")]
 mod blake3;
 mod poseidon;
 
+#[cfg(feature = "blake3")]
 pub use blake3::Blake3MerkleConfig;
 pub use poseidon::PoseidonMerkleConfig;

--- a/crypto-primitives/src/merkle_tree/configs/poseidon.rs
+++ b/crypto-primitives/src/merkle_tree/configs/poseidon.rs
@@ -1,0 +1,22 @@
+use crate::crh::poseidon::{TwoToOneCRH as PoseidonTwoToOneCRH, CRH as PoseidonCRH};
+use crate::crh::{CRHScheme, TwoToOneCRHScheme};
+use crate::merkle_tree::{Config, IdentityDigestConverter};
+use crate::sponge::Absorb;
+use ark_ff::PrimeField;
+use ark_std::marker::PhantomData;
+
+// Common config for a Merkle Tree using Poseidon (as seen in STIR, WHIR, WARP etc.)
+
+#[derive(Clone)]
+pub struct PoseidonMerkleConfig<F: PrimeField> {
+    _field: PhantomData<F>,
+}
+
+impl<F: PrimeField + Absorb> Config for PoseidonMerkleConfig<F> {
+    type Leaf = [F];
+    type LeafDigest = <Self::LeafHash as CRHScheme>::Output;
+    type LeafInnerDigestConverter = IdentityDigestConverter<Self::LeafDigest>;
+    type InnerDigest = <Self::TwoToOneHash as TwoToOneCRHScheme>::Output;
+    type LeafHash = PoseidonCRH<F>;
+    type TwoToOneHash = PoseidonTwoToOneCRH<F>;
+}

--- a/crypto-primitives/src/merkle_tree/mod.rs
+++ b/crypto-primitives/src/merkle_tree/mod.rs
@@ -22,6 +22,8 @@ use rayon::prelude::*;
 #[cfg(feature = "constraints")]
 pub mod constraints;
 
+pub mod configs;
+
 #[cfg(test)]
 mod tests;
 

--- a/crypto-primitives/src/merkle_tree/tests/mod.rs
+++ b/crypto-primitives/src/merkle_tree/tests/mod.rs
@@ -308,3 +308,57 @@ mod field_mt_tests {
         )
     }
 }
+
+mod poseidon_config_tests {
+    use crate::merkle_tree::{
+        configs::PoseidonMerkleConfig, tests::test_utils::poseidon_parameters, MerkleTree,
+    };
+    use ark_std::{test_rng, UniformRand};
+
+    type F = ark_ed_on_bls12_381::Fr;
+    type MT = MerkleTree<PoseidonMerkleConfig<F>>;
+
+    #[test]
+    fn poseidon_merkle_config_prove_verify() {
+        let mut rng = test_rng();
+        let leaves: Vec<Vec<F>> = (0..8)
+            .map(|_| (0..3).map(|_| F::rand(&mut rng)).collect())
+            .collect();
+
+        let params = poseidon_parameters();
+        let tree = MT::new(&params, &params, &leaves).unwrap();
+        let root = tree.root();
+
+        for (i, leaf) in leaves.iter().enumerate() {
+            let proof = tree.generate_proof(i).unwrap();
+            assert!(proof
+                .verify(&params, &params, &root, leaf.as_slice())
+                .unwrap());
+        }
+    }
+}
+
+#[cfg(feature = "blake3")]
+mod blake3_config_tests {
+    use crate::merkle_tree::{configs::Blake3MerkleConfig, MerkleTree};
+    use ark_std::{test_rng, UniformRand};
+
+    type F = ark_ed_on_bls12_381::Fr;
+    type MT = MerkleTree<Blake3MerkleConfig<F>>;
+
+    #[test]
+    fn blake3_merkle_config_prove_verify() {
+        let mut rng = test_rng();
+        let leaves: Vec<Vec<F>> = (0..8)
+            .map(|_| (0..3).map(|_| F::rand(&mut rng)).collect())
+            .collect();
+
+        let tree = MT::new(&(), &(), &leaves).unwrap();
+        let root = tree.root();
+
+        for (i, leaf) in leaves.iter().enumerate() {
+            let proof = tree.generate_proof(i).unwrap();
+            assert!(proof.verify(&(), &(), &root, leaf.as_slice()).unwrap());
+        }
+    }
+}

--- a/crypto-primitives/src/sponge/absorb.rs
+++ b/crypto-primitives/src/sponge/absorb.rs
@@ -6,7 +6,7 @@ use ark_ec::{
 };
 use ark_ff::{
     models::{Fp, FpConfig},
-    BigInteger, Field, PrimeField, ToConstraintField,
+    BigInteger, Field, PrimeField, SmallFp, ToConstraintField,
 };
 use ark_serialize::CanonicalSerialize;
 #[cfg(not(feature = "std"))]
@@ -159,6 +159,23 @@ impl<P: FpConfig<N>, const N: usize> Absorb for Fp<P, N> {
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
         let _ = field_cast(&[*self], dest).unwrap();
     }
+    fn batch_to_sponge_field_elements<F: PrimeField>(batch: &[Self], dest: &mut Vec<F>)
+    where
+        Self: Sized,
+    {
+        field_cast(batch, dest).unwrap();
+    }
+}
+
+impl<P: ark_ff::SmallFpConfig> Absorb for SmallFp<P> {
+    fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
+        self.serialize_compressed(dest).unwrap()
+    }
+
+    fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
+        let _ = field_cast(&[*self], dest).unwrap();
+    }
+
     fn batch_to_sponge_field_elements<F: PrimeField>(batch: &[Self], dest: &mut Vec<F>)
     where
         Self: Sized,

--- a/crypto-primitives/src/sponge/absorb.rs
+++ b/crypto-primitives/src/sponge/absorb.rs
@@ -6,7 +6,7 @@ use ark_ec::{
 };
 use ark_ff::{
     models::{Fp, FpConfig},
-    BigInteger, Field, PrimeField, SmallFp, ToConstraintField,
+    BigInteger, Field, PrimeField, ToConstraintField,
 };
 use ark_serialize::CanonicalSerialize;
 #[cfg(not(feature = "std"))]
@@ -159,23 +159,6 @@ impl<P: FpConfig<N>, const N: usize> Absorb for Fp<P, N> {
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
         let _ = field_cast(&[*self], dest).unwrap();
     }
-    fn batch_to_sponge_field_elements<F: PrimeField>(batch: &[Self], dest: &mut Vec<F>)
-    where
-        Self: Sized,
-    {
-        field_cast(batch, dest).unwrap();
-    }
-}
-
-impl<P: ark_ff::SmallFpConfig> Absorb for SmallFp<P> {
-    fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
-        self.serialize_compressed(dest).unwrap()
-    }
-
-    fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
-        let _ = field_cast(&[*self], dest).unwrap();
-    }
-
     fn batch_to_sponge_field_elements<F: PrimeField>(batch: &[Self], dest: &mut Vec<F>)
     where
         Self: Sized,


### PR DESCRIPTION
## What does this PR do?

Basically, you find nearly identical copies of the code in this PR in essentially every repo using crypto-primitives merkle trees. Instead of just moving on with that this PR adds boilerplate Merkle tree configs for BLAKE3 and Poseidon

STIR/WHIR/WARP can now just import those and delete ~100+ lines of boilerplace plus underlying `Blake3CRH` / `Blake3TwoToOneCRH` and a shared `ByteDigest<N>` output type.

NOTE: users can of course still create their own customized version of these.

Feature flag: BLAKE3 is behind a feature flag so downstream no_std targets keep working.

closes: #176 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x ] Targeted PR against correct branch (main)
- [x ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [x ] Updated relevant documentation in the code
- [x ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
