### PR TITLE
Absorb for SmallFp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Features
 
-- [\#XXX](https://github.com/arkworks-rs/crypto-primitives/pull/XXX) Implement `Absorb` for `SmallFp<P>`.
+- [\#172](https://github.com/arkworks-rs/crypto-primitives/pull/172) Implement `Absorb` for `SmallFp<P>`.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- [\#XXX](https://github.com/arkworks-rs/crypto-primitives/pull/XXX) Implement `Absorb` for `SmallFp<P>`.
+
 ### Improvements
 
 ### Bugfixes

--- a/crypto-primitives/src/sponge/absorb.rs
+++ b/crypto-primitives/src/sponge/absorb.rs
@@ -6,7 +6,7 @@ use ark_ec::{
 };
 use ark_ff::{
     models::{Fp, FpConfig},
-    BigInteger, Field, PrimeField, ToConstraintField,
+    BigInteger, Field, PrimeField, SmallFp, ToConstraintField,
 };
 use ark_serialize::CanonicalSerialize;
 #[cfg(not(feature = "std"))]
@@ -159,6 +159,23 @@ impl<P: FpConfig<N>, const N: usize> Absorb for Fp<P, N> {
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
         let _ = field_cast(&[*self], dest).unwrap();
     }
+    fn batch_to_sponge_field_elements<F: PrimeField>(batch: &[Self], dest: &mut Vec<F>)
+    where
+        Self: Sized,
+    {
+        field_cast(batch, dest).unwrap();
+    }
+}
+
+impl<P: ark_ff::SmallFpConfig> Absorb for SmallFp<P> {
+    fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
+        self.serialize_compressed(dest).unwrap()
+    }
+
+    fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
+        let _ = field_cast(&[*self], dest).unwrap();
+    }
+
     fn batch_to_sponge_field_elements<F: PrimeField>(batch: &[Self], dest: &mut Vec<F>)
     where
         Self: Sized,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Implements `Absorb` for `SmallFp<P>` (any `P: ark_ff::SmallFpConfig`), mirroring the existing `Absorb` impl for `Fp<P, N>` — bytes via `serialize_compressed`, field elements (single + batch) via `field_cast`. Lets small-field types be absorbed directly into a `CryptographicSponge` alongside their larger `Fp` cousins.

closes: #177 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x ] Targeted PR against correct branch (main)
- [ x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ x] Updated relevant documentation in the code
- [x ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
