### PR TITLE
Sync 0.6 and update num-bigint compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+- Update `num-bigint` to 0.5 to remain compatible with the `ark-serialize` 0.6 Git patch.
+
 ### Features
 
 - [\#171](https://github.com/arkworks-rs/crypto-primitives/pull/XXX) Add boilerplate for BLAKE3 (feature gated) and Poseidon Merkle tree configs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crypto-primitives", "macros"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = [ "arkworks contributors" ]
 description = "A library of useful cryptographic primitives"
 homepage = "https://arkworks.rs"

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -30,7 +30,7 @@ blake3 = { version = "1", default-features = false, optional = true }
 sha2 = { version = "0.10", default-features = false }
 digest = { version = "0.10", default-features = false }
 merlin = { version = "3.0.0", default-features = false, optional = true }
-num-bigint = { version = "0.4.4", default-features = false }
+num-bigint = { version = "0.5", default-features = false }
 
 
 rayon = { version = "1.0", optional = true }

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -21,9 +21,9 @@ ark-ff = { version = "0.6.0", default-features = false }
 ark-ec = { version = "0.6.0", default-features = false }
 ark-std = { version = "0.6.0", default-features = false }
 ark-serialize = { version = "0.6.0", default-features = false, features = [ "derive" ] }
-ark-relations = { version = "0.6", git = "https://github.com/arkworks-rs/snark.git", default-features = false }
-ark-r1cs-std = { version = "0.6", git = "https://github.com/arkworks-rs/r1cs-std", default-features = false, optional = true }
-ark-snark = { version = "0.6", git = "https://github.com/arkworks-rs/snark.git", default-features = false }
+ark-relations = { version = "0.6", default-features = false }
+ark-r1cs-std = { version = "0.6", default-features = false, optional = true }
+ark-snark = { version = "0.6", default-features = false }
 
 blake2 = { version = "0.10", default-features = false }
 blake3 = { version = "1", default-features = false, optional = true }
@@ -68,12 +68,12 @@ ahash = { version = "0.8", default-features = false }
 fnv = { version = "1.0", default-features = false }
 
 [dev-dependencies]
-ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/algebra", default-features = false, features = [ "r1cs" ] }
-ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/algebra", default-features = false, features = [ "r1cs" ] }
-ark-bls12-377 = { git = "https://github.com/arkworks-rs/algebra", default-features = false, features = [ "curve", "r1cs" ] }
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra", default-features = false, features = [ "curve" ] }
-ark-mnt4-298 = { git = "https://github.com/arkworks-rs/algebra", default-features = false, features = [ "curve", "r1cs" ] }
-ark-mnt6-298 = { git = "https://github.com/arkworks-rs/algebra", default-features = false, features = [ "r1cs" ] }
+ark-ed-on-bls12-377 = { version = "0.6.0", default-features = false, features = [ "r1cs" ] }
+ark-ed-on-bls12-381 = { version = "0.6.0", default-features = false, features = [ "r1cs" ] }
+ark-bls12-377 = { version = "0.6.0", default-features = false, features = [ "curve", "r1cs" ] }
+ark-bls12-381 = { version = "0.6.0", default-features = false, features = [ "curve" ] }
+ark-mnt4-298 = { version = "0.6.0", default-features = false, features = [ "curve", "r1cs" ] }
+ark-mnt6-298 = { version = "0.6.0", default-features = false, features = [ "r1cs" ] }
 criterion = { version = "0.6" }
 
 ################################# Benchmarks ##################################

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -15,15 +15,15 @@ edition.workspace = true
 ################################# Dependencies ################################
 
 [dependencies]
-ark-crypto-primitives-macros = { version = "0.5.0", path = "../macros" }
+ark-crypto-primitives-macros = { version = "0.6.0", path = "../macros" }
 
-ark-ff = { version = "0.5.0", default-features = false }
-ark-ec = { version = "0.5.0", default-features = false }
-ark-std = { version = "0.5.0", default-features = false }
-ark-serialize = { version = "0.5.0", default-features = false, features = [ "derive" ] }
-ark-relations = { git = "https://github.com/arkworks-rs/snark.git", default-features = false }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-features = false, optional = true }
-ark-snark = { git = "https://github.com/arkworks-rs/snark.git", default-features = false }
+ark-ff = { version = "0.6.0", default-features = false }
+ark-ec = { version = "0.6.0", default-features = false }
+ark-std = { version = "0.6.0", default-features = false }
+ark-serialize = { version = "0.6.0", default-features = false, features = [ "derive" ] }
+ark-relations = { version = "0.6", git = "https://github.com/arkworks-rs/snark.git", default-features = false }
+ark-r1cs-std = { version = "0.6", git = "https://github.com/arkworks-rs/r1cs-std", default-features = false, optional = true }
+ark-snark = { version = "0.6", git = "https://github.com/arkworks-rs/snark.git", default-features = false }
 
 blake2 = { version = "0.10", default-features = false }
 blake3 = { version = "1", default-features = false, optional = true }

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 ################################# Dependencies ################################
 
 [dependencies]
-ark-crypto-primitives-macros = { version = "0.6.0", path = "../macros" }
+ark-crypto-primitives-macros = { version = "0.5" }
 
 ark-ff = { version = "0.6.0", default-features = false }
 ark-ec = { version = "0.6.0", default-features = false }

--- a/crypto-primitives/Cargo.toml
+++ b/crypto-primitives/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 ################################# Dependencies ################################
 
 [dependencies]
-ark-crypto-primitives-macros = { version = "0.5" }
+ark-crypto-primitives-macros = { version = "0.6.0" }
 
 ark-ff = { version = "0.6.0", default-features = false }
 ark-ec = { version = "0.6.0", default-features = false }


### PR DESCRIPTION
## Summary

- Sync the 0.6 release manifest alignment into main.
- Update ark-crypto-primitives to use num-bigint 0.5, matching the current ark-serialize 0.6 Git patch.
- Keep the package version at 0.6.0; this does not introduce a further semantic-version bump.

## Root cause

When Groth16 resolves the current algebra Git patch, ark-serialize uses num-bigint 0.5 while the published crypto-primitives 0.6 crate uses 0.4. This creates incompatible BigUint types in Rescue serialization derives.

## Validation

- RUSTFLAGS=-Dwarnings cargo +stable check -p ark-crypto-primitives --no-default-features
- RUSTFLAGS=-Dwarnings cargo +stable check --all-features
- RUSTFLAGS=-Dwarnings cargo +stable test --all-features
- Groth16 all-features and aarch64-unknown-none no_std builds with this crate injected through a local Cargo patch
